### PR TITLE
Guard new and delete operators to prevent “multiple definition” compilation errors

### DIFF
--- a/src/del_op.cpp
+++ b/src/del_op.cpp
@@ -17,6 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+// Arduino 1.0 contains an implementation for this.
+#if ARDUINO < 100
+
 #include <new>
 #include <cstdlib>
 #include <func_exception>
@@ -24,3 +27,5 @@
 _UCXXEXPORT void operator delete(void* ptr) throw(){
 	free(ptr);
 }
+
+#endif

--- a/src/del_opv.cpp
+++ b/src/del_opv.cpp
@@ -17,6 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+// Arduino 1.0 contains an implementation for this.
+#if ARDUINO < 100
+
 #include <new>
 #include <cstdlib>
 #include <func_exception>
@@ -24,3 +27,5 @@
 _UCXXEXPORT void operator delete[](void * ptr) throw(){
 	free(ptr);
 }
+
+#endif

--- a/src/new_op.cpp
+++ b/src/new_op.cpp
@@ -17,6 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+// Arduino 1.0 contains an implementation for this.
+#if ARDUINO < 100
+
 #include <new>
 #include <cstdlib>
 #include <func_exception>
@@ -33,3 +36,5 @@ _UCXXEXPORT void* operator new(std::size_t numBytes) throw(std::bad_alloc){
 	}
 	return p;
 }
+
+#endif

--- a/src/new_opv.cpp
+++ b/src/new_opv.cpp
@@ -17,6 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+// Arduino 1.0 contains an implementation for this.
+#if ARDUINO < 100
+
 #include <new>
 #include <cstdlib>
 #include <func_exception>
@@ -33,3 +36,5 @@ _UCXXEXPORT void* operator new[](std::size_t numBytes) throw(std::bad_alloc){
 	}
 	return p;
 }
+
+#endif


### PR DESCRIPTION
Dear Mike,

thanks a bunch for your efforts by stepping in to provide a solid STL library for the Arduino ecosystem. As promised in maniacbug/StandardCplusplus#20, we are currently switching to ArduinoSTL. Using the `map` and `vector` container data structures improves decoupling of the sensor reading vs. telemetry domains in our firmwares to a huge amount.

So far, everything went fine when using `#include <ArduinoSTL.h>` from the main sketch. However, when moving the relevant C++ code using STL primitives to a library, we encountered the following compile time errors regarding "multiple definition"s of some operators:

    ../bin/node-gprs-http/pro328/libcore.a(new.cpp.o): In function `operator new(unsigned int)': new.cpp:(.text._Znwj+0x0): multiple definition of `operator new(unsigned int)'
    ../bin/node-gprs-http/pro328//Users/amo/dev/hiveeyes/sources/arduino/libraries/ArduinoSTL/src/new_op.cpp.o:new_op.cpp:(.text._Znwj+0x0): first defined here
    ../bin/node-gprs-http/pro328/libcore.a(new.cpp.o): In function `operator new[](unsigned int)': new.cpp:(.text._Znaj+0x0): multiple definition of `operator new[](unsigned int)'
    ../bin/node-gprs-http/pro328//Users/amo/dev/hiveeyes/sources/arduino/libraries/ArduinoSTL/src/new_opv.cpp.o:new_opv.cpp:(.text._Znaj+0x0): first defined here
    ../bin/node-gprs-http/pro328/libcore.a(new.cpp.o): In function `operator delete(void*)': new.cpp:(.text._ZdlPv+0x0): multiple definition of `operator delete(void*)'
    ../bin/node-gprs-http/pro328//Users/amo/dev/hiveeyes/sources/arduino/libraries/ArduinoSTL/src/del_op.cpp.o:del_op.cpp:(.text._ZdlPv+0x0): first defined here
    ../bin/node-gprs-http/pro328/libcore.a(new.cpp.o): In function `operator delete[](void*)': new.cpp:(.text._ZdaPv+0x0): multiple definition of `operator delete[](void*)'
    ../bin/node-gprs-http/pro328//Users/amo/dev/hiveeyes/sources/arduino/libraries/ArduinoSTL/src/del_opv.cpp.o:del_opv.cpp:(.text._ZdaPv+0x0): first defined here
    collect2: error: ld returned 1 exit status
    make: *** [../bin/node-gprs-http/pro328/node-gprs-http.elf] Error 1

It looks like this hasn't been uncommon in the history of running STL on Arduino, as we can see in these traces:
- http://stackoverflow.com/questions/37140041/arduino-and-stl
- maniacbug/StandardCplusplus#12

It was easy to mitigate this problem by guarding the relevant `new` and `delete` operators like seen in https://github.com/maniacbug/StandardCplusplus/blob/master/new_op.cpp etc. as it looks like the operators are already defined by Arduino Core.

Why these errors just show up when using STL code in a library is beyond my imagination. However, we learned about similar woes regarding C vs. C++ code in the main sketch vs. library usage and the way Arduino drives the gcc/g++ compilers.

If this doesn't break stuff for you, we would be happy to see this PR merged. Thanks in advance for your efforts again!

With kind regards,
Andreas.
