### PR TITLE
Add support for STM32 MCU based boards and fix issues with gcc 6 tool…

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A port of uClibc++ packaged as an Arduino library.
 paragraph=This library includes important C++ functions, including cout and cin, printf and scanf. It also includes STL containers like vector and algorithms. 
 category=Other
 url=https://github.com/mike-matera/ArduinoSTL
-architectures=avr,samd
+architectures=avr,samd,stm32
 includes=ArduinoSTL.h

--- a/src/cmath
+++ b/src/cmath
@@ -17,7 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #include <math.h>
+#undef _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 
 #ifndef __STD_HEADER_CMATH
 #define __STD_HEADER_CMATH 1

--- a/src/cstdlib
+++ b/src/cstdlib
@@ -16,7 +16,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #include <stdlib.h>
+#undef _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #include <basic_definitions>
 
 #ifndef __HEADER_CSTDLIB


### PR DESCRIPTION
Dear Mike,
I would like to apply this patch to have the possibility to use this library also with STM32 based boards (like Nucleo boards supported in stm32duino) and to solve some compilation issues that I have found when I have used new gcc toolchains (version 6) like the ones used on stm32duino for Nucleo boards. The patch for the new gcc toolchains should be compatible also with old gcc toolchains.
Best Regards,

Carlo