### PR TITLE
initializer_list(const T *a, size_t l) wasn't implemented properly!

### DIFF
--- a/src/initializer_list
+++ b/src/initializer_list
@@ -34,8 +34,7 @@ private:
   size_t len; 
 
   // Initialize from a { ... } construct
-  initializer_list(const T *a, size_t l) {
-  }
+  initializer_list(const T *a, size_t l): array(a), len(l) { }
 
 public:
   


### PR DESCRIPTION
The array pointer and size were ignored. As a result, code like `vector<int> v = {1, 2, 3};` would  always produce empty containers.