### PR TITLE
Enable changing the serial device. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ void setup() {
 }
 ```
 
-## Using cin an cout
-When you include this header file you automatically get cin and cout based on Serial. There isn't yet a way to select you own device at runtime. Using cin and cout is 
+## Using ```cin``` an ```cout```
+When you include this header file you automatically get cin and cout based on ```Serial```. See below for how to specify your own device. Here's an example sketch using ```cin``` and ```cout``` .
 
 ```c++
 #include <ArduinoSTL.h>
@@ -47,10 +47,40 @@ void loop() {
   }
 }
 ```
+## Changing the Serial Port 
+You can change what serial port that ```cin```, ```cout``` and ```printf()``` use. You can use built-in serial ports (e.g. ```Serial1``` on Leonardo) or you can use software serial ports that implement ```Stream```. 
+
+### Using a Built-in Port 
+In ```src/ArduinoSTL.cpp``` change the value of ```ARDUINOSTL_DEFAULT_SERIAL```. Leave the other defaults uncommented. 
+
+### Using a SoftwareSerial port. 
+Set ```ARDUINO_DEFAULT_SERAL``` to ```NULL```. Comment out the other defaults. 
+
+Here's an example sketch that uses SofwareSerial:
+
+```c++
+#include <ArduinoSTL.h>
+#include <SoftwareSerial.h>
+
+SoftwareSerial mySerial(0, 1);
+
+namespace std { 
+  ohserialstream cout(mySerial);
+  ihserialstream cin(mySerial);
+}
+
+void setup() {
+  mySerial.begin(9600);
+  ArduinoSTL_Serial.connect(mySerial);
+}
+```
+
+## Avoiding Instantiation of ```cin``` and ```cout```
+Comment out ```ARDUINOSTL_DEFAULT_CIN_COUT``` and nothing will be instantiated. You must comment out this flag if you intend to select a non-default serial port. There's no appreciable overhead for using ```printf()``` so you cannot currently avoid initializaing it.
 
 ## Known Issues
 
-Printing of floats and doubles using cout ignores format specifiers. 
+Printing of floats and doubles using ```cout``` ignores format specifiers. 
 
 uClibc seems to be fairly complete. Strings and vectors both work, even with the limited amount of heap available to Arduino. The uClibc++ status page can be found here: 
 

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ArduinoSTL
-version=1.0.5
+version=1.1.0
 author=Mike Matera <matera@lifealgorithmic.com>
 maintainer=Mike Matera <matera@lifealgorithmic.com>
 sentence=A port of uClibc++ packaged as an Arduino library.
-paragraph=This library includes important C++ functions, including cout and cin, printf and scanf. It also includes STL containers like vector and algorithms. 
+paragraph=This library includes important C++ functions, including cout and cin, printf and scanf. It also includes STL containers like vector and algorithm. 
 category=Other
 url=https://github.com/mike-matera/ArduinoSTL
 architectures=avr,samd

--- a/src/ArduinoSTL.cpp
+++ b/src/ArduinoSTL.cpp
@@ -42,7 +42,7 @@ namespace std
  */
 #if defined(ARDUINO_ARCH_AVR)
 
-ArduinoSTL_STDIO ArduinoSTL_Serial(&ARDUINOSTL_DEFAULT_SERIAL);
+ArduinoSTL_STDIO ArduinoSTL_Serial(ARDUINOSTL_DEFAULT_SERIAL);
 
 // arduino_putchar(char, FILE*) 
 //   Output a single character to the serial port. 

--- a/src/ArduinoSTL.h
+++ b/src/ArduinoSTL.h
@@ -19,4 +19,37 @@ namespace std
   extern ihserialstream cin;
 }
 
-#endif
+#if defined(ARDUINO_ARCH_AVR)
+
+class ArduinoSTL_STDIO {
+public:
+  // Initialize STDIO using a pointer to whatever Serial is. 
+  // Serial.begin() must be called at some point. 
+  ArduinoSTL_STDIO(Stream *u) : file(NULL) {
+    connect(u);
+  }
+
+  ArduinoSTL_STDIO(Stream &u) : file(NULL) {
+    connect(u);
+  }
+  
+  Stream *getUart() {
+    return uart;
+  }
+
+  void connect(Stream *u);
+
+  inline void connect(Stream &u) {
+    connect(static_cast<Stream*>(&u));
+  }
+  
+private:
+  Stream *uart;
+  FILE *file; 
+};
+
+extern ArduinoSTL_STDIO ArduinoSTL_Serial;
+
+#endif // ARDUINO_ARCH_AVR
+
+#endif // ARDUINOSTL_M_H


### PR DESCRIPTION
This patch is tested on Uno using the default and a SoftwareSerial instance. Changing the serial port on Leonardo compiles but I is not tested. 

This fixes bug #20 

Would someone please help by testing their use case? 

Here's an example that uses SoftwareSerial

```c++
#include <ArduinoSTL.h>
#include <SoftwareSerial.h>

SoftwareSerial mySerial(0, 1); // RX, TX (Hardware pins on Uno)

namespace std { 
  ohserialstream cout(mySerial);
  ihserialstream cin(mySerial);
}

void setup() {
  mySerial.begin(9600);
  ArduinoSTL_Serial.connect(mySerial);
}

void loop() {
  printf ("Hello ");
  std::cout << "World!" << std::endl;
}
```