### PR TITLE
Disable warning about incomplete limits header

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Comment out ```ARDUINOSTL_DEFAULT_CIN_COUT``` and nothing will be instantiated. 
 
 Printing of floats and doubles using ```cout``` ignores format specifiers. 
 
-uClibc seems to be fairly complete. Strings and vectors both work, even with the limited amount of heap available to Arduino. The uClibc++ status page can be found here: 
+uClibc seems to be fairly complete. Strings and vectors both work, even with the limited amount of heap available to Arduino. The limits header is apparently incomplete and inaccurate, though. The uClibc++ status page can be found here: 
 
 https://cxx.uclibc.org/status.html
 

--- a/src/limits
+++ b/src/limits
@@ -21,7 +21,8 @@
 #ifndef __STD_HEADER_LIMITS
 #define __STD_HEADER_LIMITS 1
 
-#warning limits header is nowhere complete or accurate
+// Yeah, we know...
+//#warning limits header is nowhere complete or accurate
 
 #pragma GCC visibility push(default)
 


### PR DESCRIPTION
This is essentially a copy of
https://github.com/maniacbug/StandardCplusplus/commit/2f07cf6735fc325906e6f626a904d7c988fbc1e2

This also adds a note to the README, which seems like a better place for
this.