### PR TITLE
Overloading = operator for list:

### DIFF
--- a/src/list
+++ b/src/list
@@ -20,6 +20,7 @@
 #include <memory>
 #include <iterator>
 #include <algorithm>
+#include <initializer_list>
 
 #ifndef __STD_HEADER_LIST
 #define __STD_HEADER_LIST 1
@@ -68,6 +69,16 @@ namespace std{
 			}
 			clear();
 			iterator i = x.begin();
+			while(i != x.end()){
+				push_back(*i);
+				++i;
+			}
+			return *this;
+		}
+		
+		list<T,Allocator>& operator=(const std::initializer_list<T>& x){
+			clear();
+			auto i = x.begin();
 			while(i != x.end()){
 				push_back(*i);
 				++i;


### PR DESCRIPTION
it makes possible assignment of brace-enclosed initialiser list to an std::list
i.e. std::list<int> l = {1, 2, 3};