### PR TITLE
Add <cstdint> header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ core
 *.rej
 /*.patch
 /*.diff
+
+#
+# Visual Studio
+#
+.vs

--- a/src/cstdint
+++ b/src/cstdint
@@ -1,0 +1,32 @@
+#ifndef _CPP_CSTDINT
+#define _CPP_CSTDINT 1
+
+#ifdef __GCC__
+#pragma GCC system_header
+#endif
+
+#include <stdint.h>
+
+namespace std {
+
+using :: int8_t; using :: int16_t;
+using :: int32_t; using :: int64_t;
+using :: uint8_t; using :: uint16_t;
+using :: uint32_t; using :: uint64_t;
+
+using :: int_least8_t; using :: int_least16_t;
+using :: int_least32_t; using :: int_least64_t;
+using :: uint_least8_t; using :: uint_least16_t;
+using :: uint_least32_t; using :: uint_least64_t;
+
+using :: int_fast8_t; using :: int_fast16_t;
+using :: int_fast32_t; using :: int_fast64_t;
+using :: uint_fast8_t; using :: uint_fast16_t;
+using :: uint_fast32_t; using :: uint_fast64_t;
+
+using :: intmax_t; using :: intptr_t;
+using :: uintmax_t; using :: uintptr_t;
+
+}
+
+#endif


### PR DESCRIPTION
Added <cstdint> header.

Improved Visual Studio support by ignoring .vs directory.