### PR TITLE
Expanded customization to allow for custom HardwareSerial or SoftwareSerial usage without directly editing library files

### DIFF
--- a/src/ArduinoSTL.cpp
+++ b/src/ArduinoSTL.cpp
@@ -2,24 +2,99 @@
 #include <Arduino.h>
 
 //
-// Configuration Help 
+// ## Serial Port & In/Out Configurations
 //
-// If you're using a serial port that's statically declared somewhere in
-// Arduino (e.g. Serial1 on Leonardo)
-//   1. Set ARDUINOSTL_SERIAL_DEVICE to your device
-//   2. Uncomment the ARDUINOSTL_DEFAULT_CIN_COUT flag.
+// If you're using an Arduino device that provides more than a single
+// serial port, (such as the Mega, Uno, or any other boards listed at
+// arduino.cc/reference/en/language/functions/communication/serial/),
+// and your project requires use of a non-default serial port (one of
+// Serial1, Serial2, or Serial3, instead of the default "Serial"), OR
+// if you're using an Arduino device that statically declares a non-
+// standard serial port (such as the Leonardo's "Serial1" use), then
+// perform the following steps to adjust the serial port used for the
+// streams implementation of this library:
 //
-// If you're using a sofware serial port:
-//   1. Set ARDUINOSTL_DEFAULT_SERIAL to NULL
-//   2. Comment out ARDUINOSTL_DEFAULT_CIN_COUT
-// Your sketch must contain delarations of cin and cout, and a call to
-// ArduinoSTL_serial.connect().
+//   1. Define ARDUINOSTL_DEFAULT_SERIAL to an available serial port
+//      of your choice (one of Serial, Serial1, Serial2, or Serial3),
+//      to assign the port used in this library's output and streams
+//      implementation.
+//
+//   2. Define ARDUINOSTL_DEFAULT_CIN_COUT to "true" to initialize
+//      the "cin" and "cout" behavior.
+//
+// E.g. To use "Serial2" as your serial port AND enable instantiation
+// of serial-aware implementations of "cin" and "cout" you would use:
+//
+//   >  // assign the serial port used for output to "Serial2"
+//   >  #define ARDUINOSTL_DEFAULT_SERIAL Serial2
+//   >
+//   >  // enable "cin"/"cout" behavior by defining macro to "true"
+//   >  #define ARDUINOSTL_DEFAULT_CIN_COUT true
+//   >
+//   >  // include this library only after the above, prior config
+//   >  #include <ArduinoSTL.h>
+//
+// ## Disabling Functionality / SoftwareSerial Usage
+//
+// Alternatively, if you're project requires disabling one or both
+// of these features, (for example to use SoftwareSerial instead of
+// the provided hardware serial pins), you can easily disable both
+// items selectively by following the below steps:
+//
+//   1. Define ARDUINOSTL_DISABLE_SERIAL to "true" to DISABLE serial
+//      output handling of printf and related functions.
+//
+//   2. Define ARDUINOSTL_DISABLE_CIN_COUT to "true" to DISABLE auto
+//      instantiation of "cin" and "cout" for serial output use.
+//
+// E.g. To utalize your own SoftwareSerial object instance with this
+//      library, you would use:
+//
+//   >  // disable setup of serial output handling by this lib
+//   >  #define ARDUINOSTL_DISABLE_SERIAL true
+//   >
+//   >  // disable setup of "cin"/"cout" stream behavior by this lib
+//   >  #define ARDUINOSTL_DISABLE_CIN_COUT true
+//   >
+//   >  // include this library only after the above, prior config
+//   >  #include <ArduinoSTL.h>
+//   >
+//   >  // include the external SerialSoftware dependency
+//   >  #include <SoftwareSerial.h>
+//   >
+//   >  // create instance of SoftwareSerial on pins P_RX and P_TX
+//   >  SoftwareSerial mySoftwareSerial(P_RX, P_TX);
+//   >
+//   >  // setup "cin"/"cout" by instantiating with your serial obj
+//   >  namespace std {
+//   >    ohserialstream cout(mySoftwareSerial);
+//   >    ihserialstream cin(mySoftwareSerial);
+//   >  };
+//   >
+//   >  // setup serial streaming by instantiating with your serial obj
+//   >  ArduinoSTL_serial.connect(mySoftwareSerial);
+//
+// NOTE: Defining ARDUINOSTL_DISABLE_CIN_COUT does not implicate the
+//       state of ARDUINOSTL_DISABLE_SERIAL, BUT defining the latter
+//       automatically disabled the former (as serial-based "cin" and
+//       "cout" handling cannot be setup without a serial port).
 //
 
-#define ARDUINOSTL_DEFAULT_SERIAL Serial
-#define ARDUINOSTL_DEFAULT_CIN_COUT
+#if defined ARDUINOSTL_DISABLE_SERIAL && ARDUINOSTL_DISABLE_SERIAL == true
+    #undef ARDUINOSTL_DEFAULT_SERIAL // avoid warnings about double assigs
+    #define ARDUINOSTL_DEFAULT_SERIAL NULL
+#elif ! defined ARDUINOSTL_DEFAULT_SERIAL
+    #define ARDUINOSTL_DEFAULT_SERIAL Serial
+#endif
 
-using namespace std; 
+#if (defined ARDUINOSTL_DISABLE_SERIAL && ARDUINOSTL_DISABLE_SERIAL == true) \
+ || (defined ARDUINOSTL_DISABLE_CIN_COUT && ARDUINOSTL_DISABLE_CIN_COUT == true)
+    #undef ARDUINOSTL_DEFAULT_CIN_COUT
+#elif ! defined ARDUINOSTL_DEFAULT_CIN_COUT
+    #define ARDUINOSTL_DEFAULT_CIN_COUT true
+#endif
+
+using namespace std;
 
 #ifdef ARDUINOSTL_DEFAULT_CIN_COUT
 // Create cout and cin.. there doesn't seem to be a way
@@ -44,22 +119,22 @@ namespace std
 
 ArduinoSTL_STDIO ArduinoSTL_Serial(ARDUINOSTL_DEFAULT_SERIAL);
 
-// arduino_putchar(char, FILE*) 
-//   Output a single character to the serial port. 
+// arduino_putchar(char, FILE*)
+//   Output a single character to the serial port.
 //   returns: 0 on success, 1 on error
 //   note:
 //     To maintain serial port compatibility this function
 //     automatically addes a \r when it sees a \n
-// 
+//
 static int arduino_putchar(char c, FILE* f) {
   Stream *uart = ArduinoSTL_Serial.getUart();
   if (c == '\n') uart->write('\r');
   return uart->write(c) == 1? 0 : 1;
 }
 
-// arduino_getchar(FILE*) 
+// arduino_getchar(FILE*)
 //   Take a character from the serial port. This function
-//   must block until a character is ready. 
+//   must block until a character is ready.
 //   returns: The character or -1 on a read error
 //
 static int arduino_getchar(FILE *f) {
@@ -72,7 +147,7 @@ void ArduinoSTL_STDIO::connect(Stream *u) {
   if (file != NULL)
     free (file);
   uart = u;
-  file = fdevopen(arduino_putchar, arduino_getchar); 
+  file = fdevopen(arduino_putchar, arduino_getchar);
 }
 
 #else


### PR DESCRIPTION
Prior to the changes purposed by this PR, it appeared that the only means of assigning a non-default `HardwareStream` (such as `Stream1`, `Stream2`, or `Stream3` on an Arduino Mega or Uno) for serial output integration was *by directly editing `src/ArduinoSTL.cpp` within the library itself*. This is, of course, a *suboptimal requirement*, and aside from the added complexity of manually editing the file every time one's project dependencies are cleared and pulled or even just updated, such a step introduces issues with automated testing environments (where fresh copies of dependencies are likely fetched for each build). While such automated build difficulties could obviously be overcome through custom scripts to edit the file, such a step adds *needless complexity* that serves only to create another fragile build operation that will later result in failures due to future code changes.

__This PR attempts to provide a better solution by expanding the related macro customizations *while taking care to maintain backward compatibility with prior behavior*.__

Most importantly, the meaning of all previously acceptable values for both `ARDUINOSTL_DEFAULT_SERIAL` and `ARDUINOSTL_DEFAULT_CIN_COUT` remain the same:

- `ARDUINOSTL_DEFAULT_SERIAL` Can still be defined with either a `HardwareSerial` object (to *enable* serial-directed output) or `NULL` (to *disable* serial-directed output).

- `ARDUINOSTL_DEFAULT_CIN_COUT` Can still be defined (to *toggle on* stream-aware instantiation of `cin` and `cout`) or undefined (to *toggle off* the same behavior) with its value remaining inconsequential.

The only difference in their behavior from prior is the *addition of conditional checks to determine if they have been previously assigned or not* so this library's defaults do not override values assigned to them externally (by projects consuming this library). __This change allows for `ARDUINOSTL_DEFAULT_SERIAL` and `ARDUINOSTL_DEFAULT_CIN_COUT` to be defined within the consuming project's files without editing any of the dependent library files__ (as was previously required).

Moreover, two additional macros were introduced to allow for explicit control as to which features are automatically configured. Prior, there were *two distinctly different methods required to disable both features* (with both again requiring the editing of `src/ArduinoSTL.cpp` within the library itself): `ARDUINOSTL_DEFAULT_CIN_COUT` needed its define statement removed completely to disable serial instantiation of `cin`/`cout`, and `ARDUINOSTL_DEFAULT_SERIAL` needed its value changed to `NULL` to disable serial setup of `ArduinoSTL_STDIO`. This was inconsistent.

So, to provide consistency for documented usage and enable external control over these features, the following macros were implemented:

- `ARDUINOSTL_DISABLE_SERIAL` disables the automatic serial setup of `ArduinoSTL_STDIO` (this also has the effect of disabling `cin`/`cout` as neither can be instantiated without a valid `HardwareSerial` instance.)

- `ARDUINOSTL_DISABLE_CIN_COUT` disables the automatic serial instantiation of `cin`/`cout`.

---

Please advise of any changes you would like made to expedite the merger of this PR, or if you have no interest/intent to include this feature within your project.

Assuming this functionality is desirable and accepted, I would take the time to go through any legacy documentation (such as the current `README.md`) to update the information and usage instructions to bring them in-line with the detailed comment I included at the top of `src/ArduinoSTL.cpp` in this commit.

Despite legacy behavior for `ARDUINOSTL_DEFAULT_SERIAL` and `ARDUINOSTL_DEFAULT_CIN_COUT` remaining valid, my intention for designing the conditionals in the manner I did was to simplify the external configuration of this library's behavior and I propose the following becomes the documented manner of controlling serial integration with `ArduinoSTL`:

- `ARDUINOSTL_DEFAULT_SERIAL`: Defaults to `Serial` and can be defined as any `HardwareSerial` object. *The behavior when defined as `NULL` will not be described in user-facing documentation at all*; the new macro `ARDUINOSTL_DISABLE_SERIAL` achieves the same purpose.

- `ARDUINOSTL_DISABLE_SERIAL`: Can be defined as `true` to disable this feature, while defining it as `false` or leaving it undefined enables it.

- `ARDUINOSTL_DISABLE_CIN_COUT`: Can be defined as `true` to disable this feature, while defining it as `false` or leaving it undefined enables it.

- `ARDUINOSTL_DEFAULT_CIN_COUT`: *This macro will not be described in user-facing documentation at all.*; the new macro `ARDUINOSTL_DISABLE_CIN_COUT` achieves the same purpose.