### PR TITLE
Fix bitset copy assignment operator to not run off end of array.

### DIFF
--- a/src/bitset
+++ b/src/bitset
@@ -299,7 +299,7 @@ namespace std{
 			if(&rhs == this){
 				return *this;
 			}
-			for(size_t i = 0; i <= byte_num(N); ++i){
+			for(size_t i = 0; i < num_bytes; ++i){
 				data[i] = rhs.data[i];
 			}
 			return *this;


### PR DESCRIPTION
If using a bitset with an even number of bytes, for example bitset<16>, the original code tried to copy 3 bytes instead of 2 and would run off the end of the array.
