### PR TITLE
Use local includes for the std library files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the stdio primitives. This happens automatically but the user must still call
 Serial.begin()
 
 ```c++
-#include <ArduinoSTL.h>
+#include "ArduinoSTL.h"
 
 void setup() {
   Serial.begin(9600); 
@@ -28,7 +28,7 @@ void setup() {
 When you include this header file you automatically get cin and cout based on ```Serial```. See below for how to specify your own device. Here's an example sketch using ```cin``` and ```cout``` .
 
 ```c++
-#include <ArduinoSTL.h>
+#include "ArduinoSTL.h"
 
 using namespace std;
 
@@ -59,8 +59,8 @@ Set ```ARDUINO_DEFAULT_SERAL``` to ```NULL```. Comment out the other defaults.
 Here's an example sketch that uses SofwareSerial:
 
 ```c++
-#include <ArduinoSTL.h>
-#include <SoftwareSerial.h>
+#include "ArduinoSTL.h"
+#include "SoftwareSerial.h"
 
 SoftwareSerial mySerial(0, 1);
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Here's an example sketch that uses SofwareSerial:
 
 ```c++
 #include <ArduinoSTL.h>
-#include "SoftwareSerial.h"
+#include <SoftwareSerial.h>
 
 SoftwareSerial mySerial(0, 1);
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the stdio primitives. This happens automatically but the user must still call
 Serial.begin()
 
 ```c++
-#include "ArduinoSTL.h"
+#include <ArduinoSTL.h>
 
 void setup() {
   Serial.begin(9600); 
@@ -28,7 +28,7 @@ void setup() {
 When you include this header file you automatically get cin and cout based on ```Serial```. See below for how to specify your own device. Here's an example sketch using ```cin``` and ```cout``` .
 
 ```c++
-#include "ArduinoSTL.h"
+#include <ArduinoSTL.h>
 
 using namespace std;
 
@@ -59,7 +59,7 @@ Set ```ARDUINO_DEFAULT_SERAL``` to ```NULL```. Comment out the other defaults.
 Here's an example sketch that uses SofwareSerial:
 
 ```c++
-#include "ArduinoSTL.h"
+#include <ArduinoSTL.h>
 #include "SoftwareSerial.h"
 
 SoftwareSerial mySerial(0, 1);

--- a/extras/uClibc++-OriginalFiles/extra/config/conf.c
+++ b/extras/uClibc++-OriginalFiles/extra/config/conf.c
@@ -3,12 +3,12 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <ctype.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <time.h>
-#include <sys/stat.h>
+#include "ctype.h"
+#include "stdlib.h"
+#include "string.h"
+#include "unistd.h"
+#include "time.h"
+#include "sys/stat.h"
 
 #define LKC_DIRECT_LINK
 #include "lkc.h"

--- a/extras/uClibc++-OriginalFiles/extra/config/confdata.c
+++ b/extras/uClibc++-OriginalFiles/extra/config/confdata.c
@@ -3,12 +3,12 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <sys/stat.h>
-#include <ctype.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include "sys/stat.h"
+#include "ctype.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "unistd.h"
 
 #define LKC_DIRECT_LINK
 #include "lkc.h"

--- a/extras/uClibc++-OriginalFiles/extra/config/dialog.h
+++ b/extras/uClibc++-OriginalFiles/extra/config/dialog.h
@@ -19,12 +19,12 @@
  *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <sys/types.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <ctype.h>
-#include <stdlib.h>
-#include <string.h>
+#include "sys/types.h"
+#include "fcntl.h"
+#include "unistd.h"
+#include "ctype.h"
+#include "stdlib.h"
+#include "string.h"
 
 #ifdef CURSES_LOC
 #include CURSES_LOC

--- a/extras/uClibc++-OriginalFiles/extra/config/expr.c
+++ b/extras/uClibc++-OriginalFiles/extra/config/expr.c
@@ -3,9 +3,9 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
 
 #define LKC_DIRECT_LINK
 #include "lkc.h"

--- a/extras/uClibc++-OriginalFiles/extra/config/expr.h
+++ b/extras/uClibc++-OriginalFiles/extra/config/expr.h
@@ -10,9 +10,9 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
+#include "stdio.h"
 #ifndef __cplusplus
-#include <stdbool.h>
+#include "stdbool.h"
 #endif
 
 struct file {

--- a/extras/uClibc++-OriginalFiles/extra/config/lex.zconf.c_shipped
+++ b/extras/uClibc++-OriginalFiles/extra/config/lex.zconf.c_shipped
@@ -16,10 +16,10 @@
 /* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
+#include "stdio.h"
+#include "string.h"
+#include "errno.h"
+#include "stdlib.h"
 
 /* end standard C headers. */
 
@@ -31,7 +31,7 @@
 /* C99 systems have <inttypes.h>. Non-C99 systems may or may not. */
 
 #if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
-#include <inttypes.h>
+#include "inttypes.h"
 typedef int8_t flex_int8_t;
 typedef uint8_t flex_uint8_t;
 typedef int16_t flex_int16_t;
@@ -2003,11 +2003,11 @@ char *zconftext;
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include "limits.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "unistd.h"
 
 #define LKC_DIRECT_LINK
 #include "lkc.h"
@@ -2070,7 +2070,7 @@ void alloc_string(const char *str, int size)
  * down here because we want the user's section 1 to have been scanned first.
  * The user has a chance to override it with an option.
  */
-#include <unistd.h>
+#include "unistd.h"
 
 #ifndef YY_EXTRA_TYPE
 #define YY_EXTRA_TYPE void *

--- a/extras/uClibc++-OriginalFiles/extra/config/mconf.c
+++ b/extras/uClibc++-OriginalFiles/extra/config/mconf.c
@@ -9,19 +9,19 @@
  * 2002-11-14 Petr Baudis <pasky@ucw.cz>
  */
 
-#include <sys/ioctl.h>
-#include <sys/wait.h>
-#include <sys/termios.h>
-#include <ctype.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <limits.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
-#include <termios.h>
-#include <unistd.h>
+#include "sys/ioctl.h"
+#include "sys/wait.h"
+#include "sys/termios.h"
+#include "ctype.h"
+#include "errno.h"
+#include "fcntl.h"
+#include "limits.h"
+#include "signal.h"
+#include "stdarg.h"
+#include "stdlib.h"
+#include "string.h"
+#include "termios.h"
+#include "unistd.h"
 
 #include "dialog.h"
 

--- a/extras/uClibc++-OriginalFiles/extra/config/menu.c
+++ b/extras/uClibc++-OriginalFiles/extra/config/menu.c
@@ -3,8 +3,8 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <stdlib.h>
-#include <string.h>
+#include "stdlib.h"
+#include "string.h"
 
 #define LKC_DIRECT_LINK
 #include "lkc.h"

--- a/extras/uClibc++-OriginalFiles/extra/config/symbol.c
+++ b/extras/uClibc++-OriginalFiles/extra/config/symbol.c
@@ -3,10 +3,10 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <ctype.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/utsname.h>
+#include "ctype.h"
+#include "stdlib.h"
+#include "string.h"
+#include "sys/utsname.h"
 
 #define LKC_DIRECT_LINK
 #include "lkc.h"

--- a/extras/uClibc++-OriginalFiles/extra/config/zconf.l
+++ b/extras/uClibc++-OriginalFiles/extra/config/zconf.l
@@ -7,11 +7,11 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include "limits.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "unistd.h"
 
 #define LKC_DIRECT_LINK
 #include "lkc.h"

--- a/extras/uClibc++-OriginalFiles/extra/config/zconf.tab.c_shipped
+++ b/extras/uClibc++-OriginalFiles/extra/config/zconf.tab.c_shipped
@@ -154,12 +154,12 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <ctype.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdbool.h>
+#include "ctype.h"
+#include "stdarg.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "stdbool.h"
 
 #define printd(mask, fmt...) if (cdebug & (mask)) printf(fmt)
 

--- a/extras/uClibc++-OriginalFiles/extra/config/zconf.y
+++ b/extras/uClibc++-OriginalFiles/extra/config/zconf.y
@@ -4,12 +4,12 @@
  * Released under the terms of the GNU GPL v2.0.
  */
 
-#include <ctype.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdbool.h>
+#include "ctype.h"
+#include "stdarg.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "stdbool.h"
 
 #define printd(mask, fmt...) if (cdebug & (mask)) printf(fmt)
 

--- a/extras/uClibc++-OriginalFiles/extra/locale/gen_collate.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/gen_collate.c
@@ -20,16 +20,16 @@
 #define _GNU_SOURCE
 #endif
 
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
-#include <stdarg.h>
-#include <limits.h>
-#include <ctype.h>
-#include <assert.h>
-#include <search.h>
+#include "stddef.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "stdint.h"
+#include "stdarg.h"
+#include "limits.h"
+#include "ctype.h"
+#include "assert.h"
+#include "search.h"
 
 typedef struct {
 	char *name;					/*  */

--- a/extras/uClibc++-OriginalFiles/extra/locale/gen_ldc.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/gen_ldc.c
@@ -1,9 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-#include <stdint.h>
-#include <stddef.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "assert.h"
+#include "stdint.h"
+#include "stddef.h"
 
 #ifndef __WCHAR_ENABLED
 #warning WHOA!!! __WCHAR_ENABLED is not defined! defining it now...
@@ -164,8 +164,8 @@ int main(void)
 	}
 
 	fprintf(lso,
-			"#include <stddef.h>\n"
-			"#include <stdint.h>\n"
+			"#include "stddef.h"\n"
+			"#include "stdint.h"\n"
 /* 			"#define __CTYPE_HAS_8_BIT_LOCALES\n" */
 			"#ifndef __WCHAR_ENABLED\n"
 			"#error __WCHAR_ENABLED not defined\n"

--- a/extras/uClibc++-OriginalFiles/extra/locale/gen_locale.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/gen_locale.c
@@ -1,14 +1,14 @@
 #define _GNU_SOURCE
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#include <limits.h>
-#include <assert.h>
-#include <locale.h>
-#include <langinfo.h>
-#include <nl_types.h>
-#include <stdint.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "ctype.h"
+#include "limits.h"
+#include "assert.h"
+#include "locale.h"
+#include "langinfo.h"
+#include "nl_types.h"
+#include "stdint.h"
 
 #include "c8tables.h"
 

--- a/extras/uClibc++-OriginalFiles/extra/locale/gen_mmap.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/gen_mmap.c
@@ -1,9 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-#include <stdint.h>
-#include <stddef.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "assert.h"
+#include "stdint.h"
+#include "stddef.h"
 
 #define WANT_DATA
 #include "c8tables.h"

--- a/extras/uClibc++-OriginalFiles/extra/locale/gen_wc8bit.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/gen_wc8bit.c
@@ -1,11 +1,11 @@
 #define _GNU_SOURCE
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <locale.h>
-#include <stddef.h>
-#include <wctype.h>
-#include <limits.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "locale.h"
+#include "stddef.h"
+#include "wctype.h"
+#include "limits.h"
 
 #ifndef _CTYPE_H
 #define _CTYPE_H

--- a/extras/uClibc++-OriginalFiles/extra/locale/gen_wctype.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/gen_wctype.c
@@ -1,14 +1,14 @@
 
 #define _GNU_SOURCE
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <locale.h>
-#include <wctype.h>
-#include <limits.h>
-#include <stdint.h>
-#include <wchar.h>
-#include <ctype.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "locale.h"
+#include "wctype.h"
+#include "limits.h"
+#include "stdint.h"
+#include "wchar.h"
+#include "ctype.h"
 
 #ifndef _CTYPE_H
 #define _CTYPE_H

--- a/extras/uClibc++-OriginalFiles/extra/locale/lmmtolso.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/lmmtolso.c
@@ -1,9 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "fcntl.h"
+#include "unistd.h"
+#include "sys/types.h"
+#include "sys/stat.h"
 
 int main(void)
 {
@@ -31,8 +31,8 @@ int main(void)
 	}
 
 	fprintf(lso,
-			"#include <stddef.h>\n"
-			"#include <stdint.h>\n"
+			"#include "stddef.h"\n"
+			"#include "stdint.h"\n"
 			"#include \"lt_defines.h\"\n"
 			"#include \"locale_mmap.h\"\n\n"
 			"typedef union {\n"

--- a/extras/uClibc++-OriginalFiles/extra/locale/tst_nl_langinfo.c
+++ b/extras/uClibc++-OriginalFiles/extra/locale/tst_nl_langinfo.c
@@ -1,10 +1,10 @@
 #define _GNU_SOURCE
 
-#include <locale.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <langinfo.h>
-#include <nl_types.h>
+#include "locale.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "langinfo.h"
+#include "nl_types.h"
 
 #if !defined(__UCLIBC__) && 0
 #define DO_EXTRA

--- a/extras/uClibc++-OriginalFiles/tests/algotest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/algotest.cpp
@@ -1,8 +1,8 @@
-#include <iostream>
-#include <algorithm>
-#include <functional>
-#include <vector>
-#include <set>
+#include "iostream"
+#include "algorithm"
+#include "functional"
+#include "vector"
+#include "set"
 #include "testframework.h"
 
 

--- a/extras/uClibc++-OriginalFiles/tests/bitsettest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/bitsettest.cpp
@@ -1,6 +1,6 @@
-#include <bitset>
-#include <iostream>
-#include <sstream>
+#include "bitset"
+#include "iostream"
+#include "sstream"
 
 
 int main(){

--- a/extras/uClibc++-OriginalFiles/tests/chartraitstest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/chartraitstest.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+#include "iostream"
 
 template <class T> void testClass(std::string tname);
 

--- a/extras/uClibc++-OriginalFiles/tests/combotest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/combotest.cpp
@@ -6,10 +6,10 @@
  */
 
 
-#include <iostream>
-#include <map>
-#include <string>
-#include <vector>
+#include "iostream"
+#include "map"
+#include "string"
+#include "vector"
 
 #include "testframework.h"
 

--- a/extras/uClibc++-OriginalFiles/tests/dequetest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/dequetest.cpp
@@ -1,5 +1,5 @@
-#include <deque>
-#include <iostream>
+#include "deque"
+#include "iostream"
 #include "testframework.h"
 
 void test_const(const std::deque<double> d);

--- a/extras/uClibc++-OriginalFiles/tests/excepttest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/excepttest.cpp
@@ -1,7 +1,7 @@
-#include <exception>
-#include <stdexcept>
-#include <cstdio>
-#include <cstring>
+#include "exception"
+#include "stdexcept"
+#include "cstdio"
+#include "cstring"
 
 int main(){
 	printf("Starting exception testing\n");

--- a/extras/uClibc++-OriginalFiles/tests/fstreamtest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/fstreamtest.cpp
@@ -1,5 +1,5 @@
-#include <fstream>
-#include <iostream>
+#include "fstream"
+#include "iostream"
 
 unsigned char correctValue(unsigned long int pos);
 bool testIFStreamUnderflowOnUnopened();

--- a/extras/uClibc++-OriginalFiles/tests/functionaltest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/functionaltest.cpp
@@ -1,5 +1,5 @@
-#include <functional>
-#include <cstdio>
+#include "functional"
+#include "cstdio"
 
 class Foo{
 public:

--- a/extras/uClibc++-OriginalFiles/tests/ioexceptiontest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/ioexceptiontest.cpp
@@ -1,7 +1,7 @@
-#include <sstream>
-#include <iostream>
-#include <exception>
-#include <cstring>
+#include "sstream"
+#include "iostream"
+#include "exception"
+#include "cstring"
 #include "testframework.h"
 
 bool found_no_exception(){

--- a/extras/uClibc++-OriginalFiles/tests/iotest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/iotest.cpp
@@ -1,8 +1,8 @@
-#include <iostream>
-#include <string>
-#include <iterator>
-#include <fstream>
-#include <istream>
+#include "iostream"
+#include "string"
+#include "iterator"
+#include "fstream"
+#include "istream"
 
 #include "testframework.h"
 

--- a/extras/uClibc++-OriginalFiles/tests/listtest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/listtest.cpp
@@ -1,7 +1,7 @@
-#include <list>
-#include <iostream>
-#include <vector>
-#include <string>
+#include "list"
+#include "iostream"
+#include "vector"
+#include "string"
 
 class testClass{
 public:

--- a/extras/uClibc++-OriginalFiles/tests/maptest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/maptest.cpp
@@ -1,5 +1,5 @@
-#include <map>
-#include <iostream>
+#include "map"
+#include "iostream"
 #include "testframework.h"
 
 

--- a/extras/uClibc++-OriginalFiles/tests/memorytest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/memorytest.cpp
@@ -1,5 +1,5 @@
-#include <memory>
-#include <cstdio>
+#include "memory"
+#include "cstdio"
 
 std::auto_ptr<int> intMaker();
 

--- a/extras/uClibc++-OriginalFiles/tests/mmaptest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/mmaptest.cpp
@@ -1,5 +1,5 @@
-#include <map>
-#include <iostream>
+#include "map"
+#include "iostream"
 #include "testframework.h"
 
 bool test_added_elements(){

--- a/extras/uClibc++-OriginalFiles/tests/newdeltest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/newdeltest.cpp
@@ -1,6 +1,6 @@
-#include <new>
-#include <memory>
-#include <cstdio>
+#include "new"
+#include "memory"
+#include "cstdio"
 
 struct test{
 	int a;

--- a/extras/uClibc++-OriginalFiles/tests/numerictest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/numerictest.cpp
@@ -1,6 +1,6 @@
-#include <vector>
-#include <iostream>
-#include <numeric>
+#include "vector"
+#include "iostream"
+#include "numeric"
 
 int main(){
 

--- a/extras/uClibc++-OriginalFiles/tests/settest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/settest.cpp
@@ -1,7 +1,7 @@
-#include <iostream>
-#include <algorithm>
-#include <set>
-#include <vector>
+#include "iostream"
+#include "algorithm"
+#include "set"
+#include "vector"
 
 class TEST_A
 {

--- a/extras/uClibc++-OriginalFiles/tests/sstreamtest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/sstreamtest.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
-#include <sstream>
+#include "iostream"
+#include "sstream"
 
 int main(){
 	std::cout << "Beginning sstream test\n";

--- a/extras/uClibc++-OriginalFiles/tests/stacktest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/stacktest.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
-#include <stack>
-#include <vector>
+#include "iostream"
+#include "stack"
+#include "vector"
 #include "testframework.h"
 
 

--- a/extras/uClibc++-OriginalFiles/tests/streambuftest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/streambuftest.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
-#include <fstream>
+#include "iostream"
+#include "fstream"
 
 
 int main(){

--- a/extras/uClibc++-OriginalFiles/tests/streamitertest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/streamitertest.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
-#include <cstdio>
-#include <iterator>
+#include "iostream"
+#include "cstdio"
+#include "iterator"
 
 
 int main(){

--- a/extras/uClibc++-OriginalFiles/tests/stringtest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/stringtest.cpp
@@ -1,5 +1,5 @@
-#include <string>
-#include <iostream>
+#include "string"
+#include "iostream"
 #include "testframework.h"
 
 bool checkStringCompareEquals(){

--- a/extras/uClibc++-OriginalFiles/tests/testframework.h
+++ b/extras/uClibc++-OriginalFiles/tests/testframework.h
@@ -1,6 +1,6 @@
-#include <exception>
-#include <cstdio>
-#include <typeinfo>
+#include "exception"
+#include "cstdio"
+#include "typeinfo"
 
 namespace TestFramework{
 	extern unsigned long int goodcount;

--- a/extras/uClibc++-OriginalFiles/tests/utilitytest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/utilitytest.cpp
@@ -1,5 +1,5 @@
-#include <utility>
-#include <cstdio>
+#include "utility"
+#include "cstdio"
 #include "testframework.h"
 
 using namespace std::rel_ops;

--- a/extras/uClibc++-OriginalFiles/tests/valarraytest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/valarraytest.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
-#include <valarray>
+#include "iostream"
+#include "valarray"
 
 bool check_array(std::valarray<int>& a, int b[]) {
 	for (size_t i = 0; i < a.size(); i++)
@@ -40,7 +40,7 @@ void print_array(std::string s, std::valarray<float>& a) {
 	std::cout << std::endl;
 }
 #if defined __UCLIBCXX_HAS_LONG_DOUBLE__ || defined _GLIBCXX_USE_C99_MATH_TR1
-#include <iomanip>
+#include "iomanip"
 void print_array(std::string s, std::valarray<long double>& a) {
 	std::streamsize old_precision = std::cout.precision();
 	std::cout << s << std::setprecision(old_precision - 1);

--- a/extras/uClibc++-OriginalFiles/tests/vectortest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/vectortest.cpp
@@ -1,6 +1,6 @@
-#include <vector>
-#include <string>
-#include <iostream>
+#include "vector"
+#include "string"
+#include "iostream"
 #include "testframework.h"
 
 class myclass{

--- a/extras/uClibc++-OriginalFiles/tests/wchartest.cpp
+++ b/extras/uClibc++-OriginalFiles/tests/wchartest.cpp
@@ -1,6 +1,6 @@
-#include <string>
-#include <iostream>
-#include <locale.h>
+#include "string"
+#include "iostream"
+#include "locale.h"
 
 int main(){
 	setlocale(LC_ALL, "en_US.utf8");

--- a/src/ArduinoSTL.cpp
+++ b/src/ArduinoSTL.cpp
@@ -1,4 +1,4 @@
-#include "ArduinoSTL.h"
+#include <ArduinoSTL.h>
 #include "Arduino.h"
 
 //

--- a/src/ArduinoSTL.cpp
+++ b/src/ArduinoSTL.cpp
@@ -1,5 +1,5 @@
-#include <ArduinoSTL.h>
-#include <Arduino.h>
+#include "ArduinoSTL.h"
+#include "Arduino.h"
 
 //
 // Configuration Help 

--- a/src/ArduinoSTL.h
+++ b/src/ArduinoSTL.h
@@ -9,7 +9,7 @@
 #ifndef ARDUINOSTL_M_H
 #define ARDUINOSTL_M_H
 
-#include <serstream>
+#include "serstream"
 
 // Create cout and cin.. there doesn't seem to be a way
 // to control what serial device at runtime. Grr.

--- a/src/abi/abi.cpp
+++ b/src/abi/abi.cpp
@@ -17,9 +17,9 @@
 	USA.
 */
 
-#include <cstdlib>
-#include <typeinfo>
-#include <basic_definitions>
+#include "cstdlib"
+#include "typeinfo"
+#include "basic_definitions"
 
 /* This file implements a number of the language support features
  * needed to deal with the C++ abi, as originally documented in the

--- a/src/algorithm
+++ b/src/algorithm
@@ -15,10 +15,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <cstdlib>
-#include <iterator>
-#include <utility>
-#include <functional>
+#include "cstdlib"
+#include "iterator"
+#include "utility"
+#include "functional"
 
 #ifndef __STD_HEADER_ALGORITHM
 #define __STD_HEADER_ALGORITHM 1

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -18,7 +18,7 @@
 */
 
 
-#include <algorithm>
+#include "algorithm"
 
 
 namespace std{

--- a/src/array
+++ b/src/array
@@ -1,8 +1,8 @@
 #ifndef __ARRAY__
 #define __ARRAY__
 
-#include <cstddef>
-#include <initializer_list>
+#include "cstddef"
+#include "initializer_list"
 
 namespace std {
 

--- a/src/associative_base.cpp
+++ b/src/associative_base.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include <associative_base>
+#include "associative_base"
 
 namespace std{
 

--- a/src/basic_definitions
+++ b/src/basic_definitions
@@ -18,7 +18,7 @@
 #ifndef __BASIC_DEFINITIONS
 #define __BASIC_DEFINITIONS 1
 
-#include <system_configuration.h>
+#include "system_configuration.h"
 
 #pragma GCC visibility push(default)
 

--- a/src/bitset
+++ b/src/bitset
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <cstddef>
-#include <climits>
-#include <func_exception>
-#include <string>
-#include <iosfwd>
+#include "basic_definitions"
+#include "cstddef"
+#include "climits"
+#include "func_exception"
+#include "string"
+#include "iosfwd"
 
 #ifndef __STD_BITSET_HEADER
 #define __STD_BITSET_HEADER 1

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include <bitset>
+#include "bitset"
 
 namespace std{
 

--- a/src/cassert
+++ b/src/cassert
@@ -16,4 +16,4 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <assert.h>
+#include "assert.h"

--- a/src/cctype
+++ b/src/cctype
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <ctype.h>
+#include "ctype.h"
 
 namespace std{
 

--- a/src/cerrno
+++ b/src/cerrno
@@ -16,4 +16,4 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <errno.h>
+#include "errno.h"

--- a/src/cfloat
+++ b/src/cfloat
@@ -17,13 +17,13 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <setjmp.h>
+#include "setjmp.h"
 
 #ifndef __STD_HEADER_CFLOAT
 #define __STD_HEADER_CFLOAT 1
 
 
-#include <float.h>
+#include "float.h"
 
 
 #endif

--- a/src/char_traits
+++ b/src/char_traits
@@ -16,14 +16,14 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <string.h>
-#include <exception>
-#include <memory>
+#include "basic_definitions"
+#include "string.h"
+#include "exception"
+#include "memory"
 
 #ifdef __UCLIBCXX_HAS_WCHAR__
-#include <cwchar>
-#include <cwctype>
+#include "cwchar"
+#include "cwctype"
 #endif
 
 #ifndef __HEADER_CHAR_TRAITS

--- a/src/char_traits.cpp
+++ b/src/char_traits.cpp
@@ -21,8 +21,8 @@
 #define __UCLIBCXX_COMPILE_CHAR_TRAITS__ 1
 
 
-#include <basic_definitions>
-#include <char_traits>
+#include "basic_definitions"
+#include "char_traits"
 
 namespace std{
 

--- a/src/climits
+++ b/src/climits
@@ -21,7 +21,7 @@
 #define __STD_HEADER_CLIMITS 1
 
 
-#include <limits.h>
+#include "limits.h"
 
 
 #endif

--- a/src/clocale
+++ b/src/clocale
@@ -19,7 +19,7 @@
 #ifndef __STD_HEADER_CLOCALE
 #define __STD_HEADER_CLOCALE 1
 
-#include <locale.h>
+#include "locale.h"
 
 namespace std {
 	using ::lconv;

--- a/src/cmath
+++ b/src/cmath
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <math.h>
+#include "math.h"
 
 #ifndef __STD_HEADER_CMATH
 #define __STD_HEADER_CMATH 1

--- a/src/complex
+++ b/src/complex
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <istream>
-#include <ostream>
+#include "istream"
+#include "ostream"
 
 #ifndef __STD_HEADER_COMPLEX
 #define __STD_HEADER_COMPLEX 1

--- a/src/complex.cpp
+++ b/src/complex.cpp
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <complex>
+#include "complex"
 
 
 namespace std{

--- a/src/csetjmp
+++ b/src/csetjmp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <setjmp.h>
+#include "setjmp.h"
 
 #ifndef __STD_HEADER_CSETJMP
 #define __STD_HEADER_CSETJMP 1

--- a/src/csignal
+++ b/src/csignal
@@ -46,7 +46,7 @@
 
 #pragma GCC system_header
 
-#include <signal.h>
+#include "signal.h"
 
 // Get rid of those macros defined in <signal.h> in lieu of real functions.
 #undef raise

--- a/src/cstdarg
+++ b/src/cstdarg
@@ -45,7 +45,7 @@
 
 #pragma GCC system_header
 
-#include <stdarg.h>
+#include "stdarg.h"
 
 // Adhere to section 17.4.1.2 clause 5 of ISO 14882:1998
 #ifndef va_end

--- a/src/cstddef
+++ b/src/cstddef
@@ -47,7 +47,7 @@
 #pragma GCC system_header
 #endif
 
-#include <stddef.h>
+#include "stddef.h"
 
 namespace std 
 {

--- a/src/cstdio
+++ b/src/cstdio
@@ -15,8 +15,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <stdio.h>
-#include <basic_definitions>
+#include "stdio.h"
+#include "basic_definitions"
 
 #ifndef __HEADER_CSTDIO
 #define __HEADER_CSTDIO 1

--- a/src/cstdlib
+++ b/src/cstdlib
@@ -16,8 +16,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <stdlib.h>
-#include <basic_definitions>
+#include "stdlib.h"
+#include "basic_definitions"
 
 #ifndef __HEADER_CSTDLIB
 #define __HEADER_CSTDLIB 1

--- a/src/cstring
+++ b/src/cstring
@@ -16,8 +16,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <cstddef>
-#include <string.h>
+#include "cstddef"
+#include "string.h"
 
 #ifndef __HEADER_CSTRING
 #define __HEADER_CSTRING 1

--- a/src/ctime
+++ b/src/ctime
@@ -46,9 +46,9 @@
 
 #pragma GCC system_header
 
-#include <cstddef>
+#include "cstddef"
 
-#include <time.h>
+#include "time.h"
 
 // Get rid of those macros defined in <time.h> in lieu of real functions.
 #undef clock

--- a/src/cwchar
+++ b/src/cwchar
@@ -15,8 +15,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <wchar.h>
-#include <basic_definitions>
+#include "wchar.h"
+#include "basic_definitions"
 
 #ifndef __HEADER_CWCHAR
 #define __HEADER_CWCHAR 1

--- a/src/cwctype
+++ b/src/cwctype
@@ -46,10 +46,10 @@
 
 #pragma GCC system_header
 
-//#include <bits/c++config.h>
+//#include "bits/c++config.h"
 
 #ifdef __UCLIBCXX_HAS_WCHAR__
-#include <wctype.h>
+#include "wctype.h"
 #endif
 
 // Get rid of those macros defined in <wctype.h> in lieu of real functions.

--- a/src/del_op.cpp
+++ b/src/del_op.cpp
@@ -20,9 +20,9 @@
 // Arduino 1.0 contains an implementation for this.
 #if ARDUINO < 100
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 _UCXXEXPORT void operator delete(void* ptr) throw(){
 	free(ptr);

--- a/src/del_opnt.cpp
+++ b/src/del_opnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void operator delete(void* ptr, const std::nothrow_t& ) throw() {

--- a/src/del_ops.cpp
+++ b/src/del_ops.cpp
@@ -18,9 +18,9 @@
 */
 /* C++14 sized deallocation */
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 _UCXXEXPORT void operator delete(void* ptr, std::size_t) throw(){
 	::operator delete (ptr);

--- a/src/del_opv.cpp
+++ b/src/del_opv.cpp
@@ -20,9 +20,9 @@
 // Arduino 1.0 contains an implementation for this.
 #if ARDUINO < 100
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 _UCXXEXPORT void operator delete[](void * ptr) throw(){
 	free(ptr);

--- a/src/del_opvnt.cpp
+++ b/src/del_opvnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void operator delete[](void* ptr, const std::nothrow_t& ) throw(){

--- a/src/del_opvs.cpp
+++ b/src/del_opvs.cpp
@@ -18,9 +18,9 @@
 */
 /* C++14 sized deallocation */
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 _UCXXEXPORT void operator delete[](void * ptr, std::size_t) throw(){
 	::operator delete[] (ptr);

--- a/src/deque
+++ b/src/deque
@@ -17,9 +17,9 @@
 */
 
 
-#include <memory>
-#include <iterator>
-#include <stdexcept>
+#include "memory"
+#include "iterator"
+#include "stdexcept"
 
 #pragma GCC visibility push(default)
 

--- a/src/deque.cpp
+++ b/src/deque.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include <deque>
+#include "deque"
 
 
 namespace std{

--- a/src/eh_alloc.cpp
+++ b/src/eh_alloc.cpp
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <cstdlib>
-#include <cstring>
-#include <func_exception>
+#include "cstdlib"
+#include "cstring"
+#include "func_exception"
 
 //This is a system-specific header which does all of the error-handling management
-#include <unwind-cxx.h>
+#include "unwind-cxx.h"
 
 namespace __cxxabiv1
 {

--- a/src/eh_globals.cpp
+++ b/src/eh_globals.cpp
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <cstdlib>
-#include <cstring>
-#include <func_exception>
+#include "cstdlib"
+#include "cstring"
+#include "func_exception"
 
 //This is a system-specific header which does all of the error-handling management
-#include <unwind-cxx.h>
+#include "unwind-cxx.h"
 
 //The following functionality is derived from reading of the GNU libstdc++ code and making it...simple
 

--- a/src/exception
+++ b/src/exception
@@ -37,7 +37,7 @@
 #ifndef __EXCEPTION__
 #define __EXCEPTION__
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 extern "C++" {
 

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -18,7 +18,7 @@
 
 */
 
-#include <exception>
+#include "exception"
 
 //We can't do this yet because gcc is too stupid to be able to handle
 //different implementations of exception class.

--- a/src/func_exception
+++ b/src/func_exception
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <exception>
+#include "basic_definitions"
+#include "exception"
 
 
 #ifndef HEADER_IMPLEMENTATION_FUNC_EXCEPTION

--- a/src/func_exception.cpp
+++ b/src/func_exception.cpp
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <exception>
-#include <func_exception>
-#include <stdexcept>
-#include <cstdlib>
+#include "exception"
+#include "func_exception"
+#include "stdexcept"
+#include "cstdlib"
 
 namespace std{
 

--- a/src/functional
+++ b/src/functional
@@ -19,7 +19,7 @@
 #ifndef __STD_HEADER_FUNCTIONAL
 #define __STD_HEADER_FUNCTIONAL 1
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 #pragma GCC visibility push(default)
 

--- a/src/iomanip
+++ b/src/iomanip
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <exception>
-#include <ios>
+#include "exception"
+#include "ios"
 
 #ifndef __STD_IOMANIP
 #define __STD_IOMANIP 1

--- a/src/iomanip.cpp
+++ b/src/iomanip.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <iomanip>
+#include "iomanip"
 
 namespace std{
 

--- a/src/ios
+++ b/src/ios
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <cstddef>
-#include <locale>
-#include <iosfwd>
+#include "basic_definitions"
+#include "cstddef"
+#include "locale"
+#include "iosfwd"
 
 #ifndef __HEADER_STD_IOS
 #define __HEADER_STD_IOS 1

--- a/src/ios.cpp
+++ b/src/ios.cpp
@@ -19,10 +19,10 @@
 
 #define __UCLIBCXX_COMPILE_IOS__ 1
 
-#include <ios>
-#include <ostream>
-#include <istream>
-#include <cstdio>
+#include "ios"
+#include "ostream"
+#include "istream"
+#include "cstdio"
 
 namespace std{
 

--- a/src/iosfwd
+++ b/src/iosfwd
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <char_traits>
-#include <memory>
+#include "basic_definitions"
+#include "char_traits"
+#include "memory"
 
 
 #ifndef __HEADER_STD_IOSFWD

--- a/src/iostream
+++ b/src/iostream
@@ -17,16 +17,16 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 #ifndef __HEADER_STD_IOSTREAM
 #define __HEADER_STD_IOSTREAM 1
 
-#include <iosfwd>
-#include <ios>
-#include <istream>
-#include <ostream>
-#include <string_iostream>
+#include "iosfwd"
+#include "ios"
+#include "istream"
+#include "ostream"
+#include "string_iostream"
 
 #pragma GCC visibility push(default)
 

--- a/src/iostream.cpp
+++ b/src/iostream.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_IOSTREAM__ 1
 
-#include <iostream>
+#include "iostream"
 
 namespace std{
 

--- a/src/istream
+++ b/src/istream
@@ -17,11 +17,11 @@
 	USA.
 */
 
-#include <ios>
-#include <cctype>
-#include <streambuf>
-#include <istream_helpers>
-#include <ostream>
+#include "ios"
+#include "cctype"
+#include "streambuf"
+#include "istream_helpers"
+#include "ostream"
 
 #ifndef __STD_HEADER_ISTREAM
 #define __STD_HEADER_ISTREAM 1

--- a/src/istream.cpp
+++ b/src/istream.cpp
@@ -20,7 +20,7 @@
 
 #define __UCLIBCXX_COMPILE_ISTREAM__ 1
 
-#include <istream>
+#include "istream"
 
 
 namespace std{

--- a/src/istream_helpers
+++ b/src/istream_helpers
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <ios>
-#include <cctype>
+#include "ios"
+#include "cctype"
 
-#include <string>
+#include "string"
 
 #ifndef __STD_HEADER_ISTREAM_HELPERS
 #define __STD_HEADER_ISTREAM_HELPERS 1

--- a/src/iterator
+++ b/src/iterator
@@ -17,11 +17,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <iosfwd>
-#include <cstddef>
-#include <char_traits>
-#include <iterator_base>
+#include "basic_definitions"
+#include "iosfwd"
+#include "cstddef"
+#include "char_traits"
+#include "iterator_base"
 
 
 

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <iterator>
+#include "iterator"
 
 namespace std{
 

--- a/src/iterator_base
+++ b/src/iterator_base
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 #ifndef __STD_HEADER_ITERATOR_BASE
 #define __STD_HEADER_ITERATOR_BASE 1

--- a/src/limits
+++ b/src/limits
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <climits>
+#include "climits"
 
 #ifndef __STD_HEADER_LIMITS
 #define __STD_HEADER_LIMITS 1

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include <limits>
+#include "limits"
 
 namespace std{
 

--- a/src/list
+++ b/src/list
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <memory>
-#include <iterator>
-#include <algorithm>
-#include <initializer_list>
+#include "memory"
+#include "iterator"
+#include "algorithm"
+#include "initializer_list"
 
 #ifndef __STD_HEADER_LIST
 #define __STD_HEADER_LIST 1

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <list>
+#include "list"
 
 namespace std{
 

--- a/src/locale
+++ b/src/locale
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <cstddef>
-#include <string>
+#include "basic_definitions"
+#include "cstddef"
+#include "string"
 
 #ifndef __HEADER_STD_LOCALE
 #define __HEADER_STD_LOCALE 1

--- a/src/locale.cpp
+++ b/src/locale.cpp
@@ -17,11 +17,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <locale>
-#include <cstring>
-#include <string>
-#include <stdexcept>
-#include <cctype>
+#include "locale"
+#include "cstring"
+#include "string"
+#include "stdexcept"
+#include "cctype"
 
 namespace std{
 

--- a/src/map
+++ b/src/map
@@ -18,11 +18,11 @@
 
 
 
-#include <memory>
-#include <utility>
-#include <iterator>
-#include <associative_base>
-#include <initializer_list>
+#include "memory"
+#include "utility"
+#include "iterator"
+#include "associative_base"
+#include "initializer_list"
 
 
 #ifndef __STD_HEADER_MAP

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include <map>
+#include "map"
 
 namespace std{
 

--- a/src/memory
+++ b/src/memory
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <new>
-#include <cstddef>
-#include <cstdlib>
-#include <iterator_base>
-#include <utility>
-#include <cstdio>
+#include "new"
+#include "cstddef"
+#include "cstdlib"
+#include "iterator_base"
+#include "utility"
+#include "cstdio"
 
 #ifndef HEADER_STD_MEMORY
 #define HEADER_STD_MEMORY 1

--- a/src/new
+++ b/src/new
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <exception>
-#include <cstddef>
+#include "basic_definitions"
+#include "exception"
+#include "cstddef"
 
 #ifndef __STD_NEW_OPERATOR
 #define __STD_NEW_OPERATOR 1

--- a/src/new_handler.cpp
+++ b/src/new_handler.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <new>
+#include "new"
 
 const std::nothrow_t std::nothrow = { };
 

--- a/src/new_op.cpp
+++ b/src/new_op.cpp
@@ -20,9 +20,9 @@
 // Arduino 1.0 contains an implementation for this.
 #if ARDUINO < 100
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 _UCXXEXPORT void* operator new(std::size_t numBytes) throw(std::bad_alloc){
 	//C++ stardard 5.3.4.8 requires that a valid pointer be returned for

--- a/src/new_opnt.cpp
+++ b/src/new_opnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void* operator new(std::size_t numBytes, const std::nothrow_t& ) throw(){

--- a/src/new_opv.cpp
+++ b/src/new_opv.cpp
@@ -20,9 +20,9 @@
 // Arduino 1.0 contains an implementation for this.
 #if ARDUINO < 100
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 _UCXXEXPORT void* operator new[](std::size_t numBytes) throw(std::bad_alloc){
 	//C++ stardard 5.3.4.8 requires that a valid pointer be returned for

--- a/src/new_opvnt.cpp
+++ b/src/new_opvnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <new>
-#include <cstdlib>
-#include <func_exception>
+#include "new"
+#include "cstdlib"
+#include "func_exception"
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void* operator new[](std::size_t numBytes, const std::nothrow_t& ) throw(){

--- a/src/numeric
+++ b/src/numeric
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <exception>
+#include "basic_definitions"
+#include "exception"
 
 #ifndef __STD_NUMERIC_HEADER
 #define __STD_NUMERIC_HEADER 1

--- a/src/numeric.cpp
+++ b/src/numeric.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <numeric>
+#include "numeric"
 
 namespace std{
 

--- a/src/ostream
+++ b/src/ostream
@@ -17,15 +17,15 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 #ifndef STD_HEADER_OSTREAM
 #define STD_HEADER_OSTREAM 1
 
-#include <iosfwd>
-#include <streambuf>
-#include <cstdio>
-#include <ostream_helpers>
+#include "iosfwd"
+#include "streambuf"
+#include "cstdio"
+#include "ostream_helpers"
 
 #pragma GCC visibility push(default)
 

--- a/src/ostream.cpp
+++ b/src/ostream.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_OSTREAM__ 1
 
-#include <ostream>
+#include "ostream"
 
 namespace std{
 	

--- a/src/ostream_helpers
+++ b/src/ostream_helpers
@@ -17,13 +17,13 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <stdint.h>
-#include <basic_definitions>
-#include <cstddef>
-#include <ios>
-#include <cctype>
-#include <string>
-#include <math.h> // for floor()
+#include "stdint.h"
+#include "basic_definitions"
+#include "cstddef"
+#include "ios"
+#include "cctype"
+#include "string"
+#include "math.h" // for floor()
 
 #ifndef __STD_HEADER_OSTREAM_HELPERS
 #define __STD_HEADER_OSTREAM_HELPERS 1

--- a/src/ostream_helpers.cpp
+++ b/src/ostream_helpers.cpp
@@ -6,8 +6,8 @@
  * 
  */
 
-#include <ostream_helpers>
-#include <stdio.h>
+#include "ostream_helpers"
+#include "stdio.h"
 
 namespace std {
 

--- a/src/queue
+++ b/src/queue
@@ -15,10 +15,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <deque>
-#include <vector>
-#include <functional>
+#include "basic_definitions"
+#include "deque"
+#include "vector"
+#include "functional"
 
 #ifndef __HEADER_STD_QUEUE
 #define __HEADER_STD_QUEUE 1

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <queue>
+#include "queue"
 
 
 namespace std{

--- a/src/serstream
+++ b/src/serstream
@@ -43,14 +43,14 @@
 #ifndef __810370EC_AD69_4ef7_91F5_B1AA16F14712
 #define __810370EC_AD69_4ef7_91F5_B1AA16F14712
 
-#include <basic_definitions>
+#include "basic_definitions"
 
-#include <iosfwd>
-#include <ios>
-#include <istream>
-#include <ostream>
-#include <iostream>
-#include <Stream.h>
+#include "iosfwd"
+#include "ios"
+#include "istream"
+#include "ostream"
+#include "iostream"
+#include "Stream.h"
 
 namespace std
 {

--- a/src/set
+++ b/src/set
@@ -21,9 +21,9 @@
 #include<memory>
 #include<utility>
 #include<iterator>
-#include <deque>
+#include "deque"
 #include<functional>
-#include <associative_base>
+#include "associative_base"
 
 #ifndef __STD_HEADER_SET
 #define __STD_HEADER_SET

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include <set>
+#include "set"
 
 namespace std{
 

--- a/src/sstream
+++ b/src/sstream
@@ -17,17 +17,17 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 #ifndef HEADER_STD_SSTREAM
 #define HEADER_STD_SSTREAM 1
 
-#include <iosfwd>
-#include <ios>
-#include <istream>
-#include <ostream>
-#include <iostream>
-#include <string>
+#include "iosfwd"
+#include "ios"
+#include "istream"
+#include "ostream"
+#include "iostream"
+#include "string"
 
 #pragma GCC visibility push(default)
 

--- a/src/sstream.cpp
+++ b/src/sstream.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_SSTREAM__ 1
 
-#include <sstream>
+#include "sstream"
 
 namespace std{
 

--- a/src/stack
+++ b/src/stack
@@ -15,8 +15,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <deque>
+#include "basic_definitions"
+#include "deque"
 
 #ifndef __HEADER_STD_STACK
 #define __HEADER_STD_STACK 1

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <stack>
+#include "stack"
 
 
 namespace std{

--- a/src/stdexcept
+++ b/src/stdexcept
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <exception>
-#include <string>
+#include "basic_definitions"
+#include "exception"
+#include "string"
 
 #ifndef HEADER_STD_EXCEPTIONS
 #define HEADER_STD_EXCEPTIONS 1

--- a/src/stdexcept.cpp
+++ b/src/stdexcept.cpp
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <exception>
-#include <stdexcept>
+#include "exception"
+#include "stdexcept"
 
 #ifdef __UCLIBCXX_EXCEPTION_SUPPORT__
 

--- a/src/streambuf
+++ b/src/streambuf
@@ -17,15 +17,15 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <locale>
-#include <string>
-#include <iosfwd>
+#include "basic_definitions"
+#include "locale"
+#include "string"
+#include "iosfwd"
 
 #ifndef HEADER_STD_STREAMBUF
 #define HEADER_STD_STREAMBUF 1
 
-#include <ios>
+#include "ios"
 
 #pragma GCC visibility push(default)
 

--- a/src/streambuf.cpp
+++ b/src/streambuf.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_STREAMBUF__ 1
 
-#include <streambuf>
+#include "streambuf"
 
 namespace std{
 

--- a/src/string
+++ b/src/string
@@ -17,17 +17,17 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <char_traits>
-#include <string.h>
-#include <func_exception>
-#include <memory>
-#include <vector>
+#include "basic_definitions"
+#include "char_traits"
+#include "string.h"
+#include "func_exception"
+#include "memory"
+#include "vector"
 
 
 #ifdef __UCLIBCXX_HAS_WCHAR__
-#include <cwchar>
-#include <cwctype>
+#include "cwchar"
+#include "cwctype"
 #endif
 
 #ifndef __HEADER_STD_STRING

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -19,12 +19,12 @@
 
 #define __UCLIBCXX_COMPILE_STRING__ 1
 
-#include <basic_definitions>
-#include <char_traits>
-#include <string>
-#include <string_iostream>
-#include <string.h>
-#include <ostream>
+#include "basic_definitions"
+#include "char_traits"
+#include "string"
+#include "string_iostream"
+#include "string.h"
+#include "ostream"
 
 namespace std{
 

--- a/src/string_iostream
+++ b/src/string_iostream
@@ -17,13 +17,13 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <istream>
-#include <ostream>
-#include <string>
+#include "istream"
+#include "ostream"
+#include "string"
 
 #ifdef __UCLIBCXX_HAS_WCHAR__
-#include <cwchar>
-#include <cwctype>
+#include "cwchar"
+#include "cwctype"
 #endif
 
 #ifndef __HEADER_STD_STRING_IOSTREAM

--- a/src/support
+++ b/src/support
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <exception>
-#include <cstdlib>
-#include <typeinfo>
+#include "exception"
+#include "cstdlib"
+#include "typeinfo"
 
 #ifndef HEADER_ULC_SUPPORT
 #define HEADER_ULC_SUPPORT 1

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <support>
+#include "support"
 
 /*extern "C" void *__cxa_allocate_exception(size_t thrown_size){
 	void * retval;

--- a/src/type_traits
+++ b/src/type_traits
@@ -16,11 +16,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
-#include <string.h>
-#include <exception>
-#include <memory>
-#include <char_traits>
+#include "basic_definitions"
+#include "string.h"
+#include "exception"
+#include "memory"
+#include "char_traits"
 
 #ifndef __HEADER_TYPE_TRAITS
 #define __HEADER_TYPE_TRAITS 1

--- a/src/typeinfo
+++ b/src/typeinfo
@@ -35,7 +35,7 @@
 #ifndef __TYPEINFO__
 #define __TYPEINFO__
 
-#include <exception>
+#include "exception"
 
 extern "C++" {
 

--- a/src/typeinfo.cpp
+++ b/src/typeinfo.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <typeinfo>
+#include "typeinfo"
 
 namespace std{
 

--- a/src/unwind-cxx.h
+++ b/src/unwind-cxx.h
@@ -35,9 +35,9 @@
 
 // Level 2: C++ ABI
 
-#include <typeinfo>
-#include <exception>
-#include <cstddef>
+#include "typeinfo"
+#include "exception"
+#include "cstddef"
 #include "unwind.h"
 
 #ifdef __aarch64__

--- a/src/utility
+++ b/src/utility
@@ -18,7 +18,7 @@
 */
 
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 
 #ifndef __STD_HEADER_UTILITY

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -18,7 +18,7 @@
 */
 
 
-#include <utility>
+#include "utility"
 
 
 namespace std{

--- a/src/valarray
+++ b/src/valarray
@@ -17,13 +17,13 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <basic_definitions>
+#include "basic_definitions"
 
 #ifndef __HEADER_STD_VALARRAY
 #define __HEADER_STD_VALARRAY 1
 
-#include <cstddef>
-#include <cmath>
+#include "cstddef"
+#include "cmath"
 
 #pragma GCC visibility push(default)
 

--- a/src/valarray.cpp
+++ b/src/valarray.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <valarray>
+#include "valarray"
 
 namespace std{
 

--- a/src/vector
+++ b/src/vector
@@ -18,13 +18,13 @@
 
 */
 
-#include <basic_definitions>
-#include <memory>
-#include <iterator>
-#include <func_exception>
-#include <algorithm>
-#include <type_traits>
-#include <initializer_list>
+#include "basic_definitions"
+#include "memory"
+#include "iterator"
+#include "func_exception"
+#include "algorithm"
+#include "type_traits"
+#include "initializer_list"
 
 #ifndef __STD_HEADER_VECTOR
 #define __STD_HEADER_VECTOR

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -20,7 +20,7 @@
 #define __UCLIBCXX_COMPILE_VECTOR__ 1
 
 
-#include <vector>
+#include "vector"
 
 namespace std{
 


### PR DESCRIPTION
This prevents conflicts with other std library implementations in the search path, such as those installed by Visual Studio. Fixes #56 .