### PR TITLE
Correct array initialisation

### DIFF
--- a/src/array
+++ b/src/array
@@ -18,22 +18,9 @@ public:
 	typedef const_pointer const_iterator;
 	typedef size_t size_type;
 
-private:
 	value_type _data[N ? N : 1];
 
 public:
-	array() = default;
-	array(std::initializer_list<T> init) {
-		if (init.size() != N) {
-			// error
-		}
-		size_t i = 0;
-		for(const auto& item : init) {
-			_data[i++] = item;
-		}
-	}
-	array& operator=(const array& other) = default;
-
 	reference operator[](size_type i) { return _data[i]; }
 	const_reference operator[](size_type i) const { return _data[i]; }
 	reference front() { return _data[0]; }


### PR DESCRIPTION
std::array<int,5> test={ 1 };
should fill element 1 to 4 with 0;

In other library the member data element is public
to allow compiler to fill it directly.
Use same principle.

A code example that test this:

```cpp
#ifdef ARDUINO
#include <ArduinoSTL.h>
#endif

#include <array>
#include <iostream>

std::array<int16_t, 8> test_array;

void test()
{
  test_array = {0, 1, 2, 3, 4, 5, 6, 7};
  std::cout << "Value shoud be 0 1 2 3 4 5 6 7  : ";
  for (auto values : test_array)
  {
    std::cout << values << " ";
  }
  std::cout << std::endl;

  test_array = {5, 5};

  std::cout << "Value shoud be 5 5 0 0 0 0 0 0  : ";
  for (auto values : test_array)
  {
    std::cout << values << " ";
  }
  std::cout << std::endl;
}

#ifdef ARDUINO
void setup()
{
  Serial.begin(115200);
}

void loop()
{
  test();
}
#else
int main(int argc, char **args)
{
  while(true)
    test();
}
#endif
```

