### PR TITLE
Omit all new and delete implementation when AVR core provides it

### DIFF
--- a/src/ArduinoSTL.cpp
+++ b/src/ArduinoSTL.cpp
@@ -1,4 +1,4 @@
-#include "ArduinoSTL.h"
+#include <ArduinoSTL.h>
 #include <Arduino.h>
 
 //

--- a/src/ArduinoSTL.h
+++ b/src/ArduinoSTL.h
@@ -10,7 +10,7 @@
 #define ARDUINOSTL_M_H
 
 #include <Arduino.h>
-#include "serstream"
+#include <serstream>
 
 // Create cout and cin.. there doesn't seem to be a way
 // to control what serial device at runtime. Grr.

--- a/src/abi/abi.cpp
+++ b/src/abi/abi.cpp
@@ -17,9 +17,9 @@
 	USA.
 */
 
-#include "cstdlib"
-#include "typeinfo"
-#include "basic_definitions"
+#include <cstdlib>
+#include <typeinfo>
+#include <basic_definitions>
 
 /* This file implements a number of the language support features
  * needed to deal with the C++ abi, as originally documented in the

--- a/src/algorithm
+++ b/src/algorithm
@@ -15,10 +15,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "cstdlib"
-#include "iterator"
-#include "utility"
-#include "functional"
+#include <cstdlib>
+#include <iterator>
+#include <utility>
+#include <functional>
 
 #ifndef __STD_HEADER_ALGORITHM
 #define __STD_HEADER_ALGORITHM 1

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -18,7 +18,7 @@
 */
 
 
-#include "algorithm"
+#include <algorithm>
 
 
 namespace std{

--- a/src/array
+++ b/src/array
@@ -1,8 +1,8 @@
 #ifndef __ARRAY__
 #define __ARRAY__
 
-#include "cstddef"
-#include "initializer_list"
+#include <cstddef>
+#include <initializer_list>
 
 namespace std {
 

--- a/src/associative_base
+++ b/src/associative_base
@@ -18,11 +18,11 @@
 
 
 
-#include "memory"
-#include "utility"
-#include "iterator"
-#include "functional"
-#include "list"
+#include<memory>
+#include<utility>
+#include<iterator>
+#include<functional>
+#include<list>
 
 
 #ifndef __STD_HEADER_ASSOCIATIVE_BASE

--- a/src/associative_base.cpp
+++ b/src/associative_base.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include "associative_base"
+#include <associative_base>
 
 namespace std{
 

--- a/src/basic_definitions
+++ b/src/basic_definitions
@@ -18,7 +18,7 @@
 #ifndef __BASIC_DEFINITIONS
 #define __BASIC_DEFINITIONS 1
 
-#include "system_configuration.h"
+#include <system_configuration.h>
 
 #pragma GCC visibility push(default)
 

--- a/src/bitset
+++ b/src/bitset
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "cstddef"
-#include "climits"
-#include "func_exception"
-#include "string"
-#include "iosfwd"
+#include <basic_definitions>
+#include <cstddef>
+#include <climits>
+#include <func_exception>
+#include <string>
+#include <iosfwd>
 
 #ifndef __STD_BITSET_HEADER
 #define __STD_BITSET_HEADER 1

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include "bitset"
+#include <bitset>
 
 namespace std{
 

--- a/src/char_traits
+++ b/src/char_traits
@@ -16,14 +16,14 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
+#include <basic_definitions>
 #include <string.h>
-#include "exception"
-#include "memory"
+#include <exception>
+#include <memory>
 
 #ifdef __UCLIBCXX_HAS_WCHAR__
-#include "cwchar"
-#include "cwctype"
+#include <cwchar>
+#include <cwctype>
 #endif
 
 #ifndef __HEADER_CHAR_TRAITS

--- a/src/char_traits.cpp
+++ b/src/char_traits.cpp
@@ -21,8 +21,8 @@
 #define __UCLIBCXX_COMPILE_CHAR_TRAITS__ 1
 
 
-#include "basic_definitions"
-#include "char_traits"
+#include <basic_definitions>
+#include <char_traits>
 
 namespace std{
 

--- a/src/complex
+++ b/src/complex
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "istream"
-#include "ostream"
+#include <istream>
+#include <ostream>
 
 #ifndef __STD_HEADER_COMPLEX
 #define __STD_HEADER_COMPLEX 1

--- a/src/complex.cpp
+++ b/src/complex.cpp
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "complex"
+#include <complex>
 
 
 namespace std{

--- a/src/cstdio
+++ b/src/cstdio
@@ -16,7 +16,7 @@
 */
 
 #include <stdio.h>
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef __HEADER_CSTDIO
 #define __HEADER_CSTDIO 1

--- a/src/cstdlib
+++ b/src/cstdlib
@@ -17,7 +17,7 @@
 */
 
 #include <stdlib.h>
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef __HEADER_CSTDLIB
 #define __HEADER_CSTDLIB 1

--- a/src/cstring
+++ b/src/cstring
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "cstddef"
+#include <cstddef>
 #include <string.h>
 
 #ifndef __HEADER_CSTRING

--- a/src/ctime
+++ b/src/ctime
@@ -46,7 +46,7 @@
 
 #pragma GCC system_header
 
-#include "cstddef"
+#include <cstddef>
 
 #include <time.h>
 

--- a/src/cwchar
+++ b/src/cwchar
@@ -16,7 +16,7 @@
 */
 
 #include <wchar.h>
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef __HEADER_CWCHAR
 #define __HEADER_CWCHAR 1

--- a/src/del_op.cpp
+++ b/src/del_op.cpp
@@ -17,15 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-// Arduino 1.0 contains an implementation for this.
-#if ARDUINO < 100
-
 #include <new>
 #include <cstdlib>
 #include <func_exception>
 
+#if defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100
 _UCXXEXPORT void operator delete(void* ptr) _UCXX_USE_NOEXCEPT{
 	free(ptr);
 }
-
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100

--- a/src/del_opnt.cpp
+++ b/src/del_opnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "new"
-#include "cstdlib"
-#include "func_exception"
+#include <new>
+#include <cstdlib>
+#include <func_exception>
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void operator delete(void* ptr, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT {

--- a/src/del_opnt.cpp
+++ b/src/del_opnt.cpp
@@ -21,8 +21,8 @@
 #include <cstdlib>
 #include <func_exception>
 
-#ifndef NO_NOTHROW
+#if defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)
 _UCXXEXPORT void operator delete(void* ptr, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT {
 	free(ptr);
 }
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)

--- a/src/del_ops.cpp
+++ b/src/del_ops.cpp
@@ -22,6 +22,8 @@
 #include <cstdlib>
 #include <func_exception>
 
+#if defined(USING_NEW_FROM_UCLIBC)
 _UCXXEXPORT void operator delete(void* ptr, std::size_t) _UCXX_USE_NOEXCEPT{
 	::operator delete (ptr);
 }
+#endif // defined(USING_NEW_FROM_UCLIBC)

--- a/src/del_ops.cpp
+++ b/src/del_ops.cpp
@@ -18,9 +18,9 @@
 */
 /* C++14 sized deallocation */
 
-#include "new"
-#include "cstdlib"
-#include "func_exception"
+#include <new>
+#include <cstdlib>
+#include <func_exception>
 
 _UCXXEXPORT void operator delete(void* ptr, std::size_t) _UCXX_USE_NOEXCEPT{
 	::operator delete (ptr);

--- a/src/del_opv.cpp
+++ b/src/del_opv.cpp
@@ -17,9 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-// Arduino 1.0 contains an implementation for this.
-#if ARDUINO < 100
-
+#if defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100
 #include <new>
 #include <cstdlib>
 #include <func_exception>
@@ -27,5 +25,4 @@
 _UCXXEXPORT void operator delete[](void * ptr) _UCXX_USE_NOEXCEPT{
 	free(ptr);
 }
-
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100

--- a/src/del_opvnt.cpp
+++ b/src/del_opvnt.cpp
@@ -21,8 +21,8 @@
 #include <cstdlib>
 #include <func_exception>
 
-#ifndef NO_NOTHROW
+#if defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)
 _UCXXEXPORT void operator delete[](void* ptr, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT{
 	free(ptr);
 }
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)

--- a/src/del_opvnt.cpp
+++ b/src/del_opvnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "new"
-#include "cstdlib"
-#include "func_exception"
+#include <new>
+#include <cstdlib>
+#include <func_exception>
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void operator delete[](void* ptr, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT{

--- a/src/del_opvs.cpp
+++ b/src/del_opvs.cpp
@@ -18,9 +18,9 @@
 */
 /* C++14 sized deallocation */
 
-#include "new"
-#include "cstdlib"
-#include "func_exception"
+#include <new>
+#include <cstdlib>
+#include <func_exception>
 
 _UCXXEXPORT void operator delete[](void * ptr, std::size_t) _UCXX_USE_NOEXCEPT{
 	::operator delete[] (ptr);

--- a/src/del_opvs.cpp
+++ b/src/del_opvs.cpp
@@ -22,6 +22,8 @@
 #include <cstdlib>
 #include <func_exception>
 
+#if defined(USING_NEW_FROM_UCLIBC)
 _UCXXEXPORT void operator delete[](void * ptr, std::size_t) _UCXX_USE_NOEXCEPT{
 	::operator delete[] (ptr);
 }
+#endif // defined(USING_NEW_FROM_UCLIBC)

--- a/src/deque
+++ b/src/deque
@@ -17,9 +17,9 @@
 */
 
 
-#include "memory"
-#include "iterator"
-#include "stdexcept"
+#include <memory>
+#include <iterator>
+#include <stdexcept>
 
 #pragma GCC visibility push(default)
 

--- a/src/deque.cpp
+++ b/src/deque.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include "deque"
+#include <deque>
 
 
 namespace std{

--- a/src/eh_alloc.cpp
+++ b/src/eh_alloc.cpp
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "cstdlib"
-#include "cstring"
-#include "func_exception"
+#include <cstdlib>
+#include <cstring>
+#include <func_exception>
 
 //This is a system-specific header which does all of the error-handling management
-#include "unwind-cxx.h"
+#include <unwind-cxx.h>
 
 namespace __cxxabiv1
 {

--- a/src/eh_globals.cpp
+++ b/src/eh_globals.cpp
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "cstdlib"
-#include "cstring"
-#include "func_exception"
+#include <cstdlib>
+#include <cstring>
+#include <func_exception>
 
 //This is a system-specific header which does all of the error-handling management
-#include "unwind-cxx.h"
+#include <unwind-cxx.h>
 
 //The following functionality is derived from reading of the GNU libstdc++ code and making it...simple
 

--- a/src/exception
+++ b/src/exception
@@ -37,7 +37,7 @@
 #ifndef __EXCEPTION__
 #define __EXCEPTION__
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 extern "C++" {
 

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -18,7 +18,7 @@
 
 */
 
-#include "exception"
+#include <exception>
 
 //We can't do this yet because gcc is too stupid to be able to handle
 //different implementations of exception class.

--- a/src/func_exception
+++ b/src/func_exception
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "exception"
+#include <basic_definitions>
+#include <exception>
 
 
 #ifndef HEADER_IMPLEMENTATION_FUNC_EXCEPTION

--- a/src/func_exception.cpp
+++ b/src/func_exception.cpp
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "exception"
-#include "func_exception"
-#include "stdexcept"
-#include "cstdlib"
+#include <exception>
+#include <func_exception>
+#include <stdexcept>
+#include <cstdlib>
 
 namespace std{
 

--- a/src/functional
+++ b/src/functional
@@ -19,7 +19,7 @@
 #ifndef __STD_HEADER_FUNCTIONAL
 #define __STD_HEADER_FUNCTIONAL 1
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 #pragma GCC visibility push(default)
 

--- a/src/iomanip
+++ b/src/iomanip
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "exception"
-#include "ios"
+#include <exception>
+#include <ios>
 
 #ifndef __STD_IOMANIP
 #define __STD_IOMANIP 1

--- a/src/iomanip.cpp
+++ b/src/iomanip.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "iomanip"
+#include <iomanip>
 
 namespace std{
 

--- a/src/ios
+++ b/src/ios
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "cstddef"
-#include "locale"
-#include "iosfwd"
+#include <basic_definitions>
+#include <cstddef>
+#include <locale>
+#include <iosfwd>
 
 #ifndef __HEADER_STD_IOS
 #define __HEADER_STD_IOS 1

--- a/src/ios.cpp
+++ b/src/ios.cpp
@@ -19,10 +19,10 @@
 
 #define __UCLIBCXX_COMPILE_IOS__ 1
 
-#include "ios"
-#include "ostream"
-#include "istream"
-#include "cstdio"
+#include <ios>
+#include <ostream>
+#include <istream>
+#include <cstdio>
 
 namespace std{
 

--- a/src/iosfwd
+++ b/src/iosfwd
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "char_traits"
-#include "memory"
+#include <basic_definitions>
+#include <char_traits>
+#include <memory>
 
 
 #ifndef __HEADER_STD_IOSFWD

--- a/src/iostream
+++ b/src/iostream
@@ -17,16 +17,16 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef __HEADER_STD_IOSTREAM
 #define __HEADER_STD_IOSTREAM 1
 
-#include "iosfwd"
-#include "ios"
-#include "istream"
-#include "ostream"
-#include "string_iostream"
+#include <iosfwd>
+#include <ios>
+#include <istream>
+#include <ostream>
+#include <string_iostream>
 
 #pragma GCC visibility push(default)
 

--- a/src/iostream.cpp
+++ b/src/iostream.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_IOSTREAM__ 1
 
-#include "iostream"
+#include <iostream>
 
 namespace std{
 

--- a/src/istream
+++ b/src/istream
@@ -17,11 +17,11 @@
 	USA.
 */
 
-#include "ios"
-#include "cctype"
-#include "streambuf"
-#include "istream_helpers"
-#include "ostream"
+#include <ios>
+#include <cctype>
+#include <streambuf>
+#include <istream_helpers>
+#include <ostream>
 
 #ifndef __STD_HEADER_ISTREAM
 #define __STD_HEADER_ISTREAM 1

--- a/src/istream.cpp
+++ b/src/istream.cpp
@@ -20,7 +20,7 @@
 
 #define __UCLIBCXX_COMPILE_ISTREAM__ 1
 
-#include "istream"
+#include <istream>
 
 
 namespace std{

--- a/src/istream_helpers
+++ b/src/istream_helpers
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "ios"
-#include "cctype"
+#include <ios>
+#include <cctype>
 
-#include "string"
+#include <string>
 
 #ifndef __STD_HEADER_ISTREAM_HELPERS
 #define __STD_HEADER_ISTREAM_HELPERS 1

--- a/src/iterator
+++ b/src/iterator
@@ -17,11 +17,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "iosfwd"
-#include "cstddef"
-#include "char_traits"
-#include "iterator_base"
+#include <basic_definitions>
+#include <iosfwd>
+#include <cstddef>
+#include <char_traits>
+#include <iterator_base>
 
 
 

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "iterator"
+#include <iterator>
 
 namespace std{
 

--- a/src/iterator_base
+++ b/src/iterator_base
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef __STD_HEADER_ITERATOR_BASE
 #define __STD_HEADER_ITERATOR_BASE 1

--- a/src/limits
+++ b/src/limits
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "climits"
+#include <climits>
 
 #ifndef __STD_HEADER_LIMITS
 #define __STD_HEADER_LIMITS 1

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include "limits"
+#include <limits>
 
 namespace std{
 

--- a/src/list
+++ b/src/list
@@ -17,10 +17,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "memory"
-#include "iterator"
-#include "algorithm"
-#include "initializer_list"
+#include <memory>
+#include <iterator>
+#include <algorithm>
+#include <initializer_list>
 
 #ifndef __STD_HEADER_LIST
 #define __STD_HEADER_LIST 1

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "list"
+#include <list>
 
 namespace std{
 

--- a/src/locale
+++ b/src/locale
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "cstddef"
-#include "string"
+#include <basic_definitions>
+#include <cstddef>
+#include <string>
 
 #ifndef __HEADER_STD_LOCALE
 #define __HEADER_STD_LOCALE 1

--- a/src/locale.cpp
+++ b/src/locale.cpp
@@ -17,11 +17,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "locale"
-#include "cstring"
-#include "string"
-#include "stdexcept"
-#include "cctype"
+#include <locale>
+#include <cstring>
+#include <string>
+#include <stdexcept>
+#include <cctype>
 
 namespace std{
 

--- a/src/map
+++ b/src/map
@@ -18,11 +18,11 @@
 
 
 
-#include "memory"
-#include "utility"
-#include "iterator"
-#include "associative_base"
-#include "initializer_list"
+#include <memory>
+#include <utility>
+#include <iterator>
+#include <associative_base>
+#include <initializer_list>
 
 
 #ifndef __STD_HEADER_MAP

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include "map"
+#include <map>
 
 namespace std{
 

--- a/src/memory
+++ b/src/memory
@@ -17,12 +17,12 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "new"
-#include "cstddef"
-#include "cstdlib"
-#include "iterator_base"
-#include "utility"
-#include "cstdio"
+#include <new>
+#include <cstddef>
+#include <cstdlib>
+#include <iterator_base>
+#include <utility>
+#include <cstdio>
 
 #ifndef HEADER_STD_MEMORY
 #define HEADER_STD_MEMORY 1

--- a/src/new
+++ b/src/new
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "exception"
-#include "cstddef"
+#include <basic_definitions>
+#include <exception>
+#include <cstddef>
 
 #ifndef __STD_NEW_OPERATOR
 #define __STD_NEW_OPERATOR 1

--- a/src/new
+++ b/src/new
@@ -24,6 +24,8 @@
 #ifndef __STD_NEW_OPERATOR
 #define __STD_NEW_OPERATOR 1
 
+#define USING_NEW_FROM_UCLIBC
+
 #pragma GCC visibility push(default)
 
 namespace std{

--- a/src/new_handler.cpp
+++ b/src/new_handler.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "new"
+#include <new>
 
 const std::nothrow_t std::nothrow = { };
 

--- a/src/new_handler.cpp
+++ b/src/new_handler.cpp
@@ -19,6 +19,7 @@
 
 #include <new>
 
+#if defined(USING_NEW_FROM_UCLIBC)
 const std::nothrow_t std::nothrow = { };
 
 //Name selected to be compatable with g++ code
@@ -29,3 +30,4 @@ _UCXXEXPORT std::new_handler std::set_new_handler(std::new_handler new_p) _UCXX_
 	__new_handler = new_p;
 	return retval;
 }
+#endif // defined(USING_NEW_FROM_UCLIBC)

--- a/src/new_op.cpp
+++ b/src/new_op.cpp
@@ -17,13 +17,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-// Arduino 1.0 contains an implementation for this.
-#if ARDUINO < 100
-
 #include <new>
 #include <cstdlib>
 #include <func_exception>
 
+#if defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100
 _UCXXEXPORT void* operator new(std::size_t numBytes) _UCXX_THROW(std::bad_alloc)
 {
 	//C++ stardard 5.3.4.8 requires that a valid pointer be returned for
@@ -37,5 +35,4 @@ _UCXXEXPORT void* operator new(std::size_t numBytes) _UCXX_THROW(std::bad_alloc)
 	}
 	return p;
 }
-
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100

--- a/src/new_opnt.cpp
+++ b/src/new_opnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "new"
-#include "cstdlib"
-#include "func_exception"
+#include <new>
+#include <cstdlib>
+#include <func_exception>
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void* operator new(std::size_t numBytes, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT{

--- a/src/new_opnt.cpp
+++ b/src/new_opnt.cpp
@@ -21,8 +21,8 @@
 #include <cstdlib>
 #include <func_exception>
 
-#ifndef NO_NOTHROW
+#if defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)
 _UCXXEXPORT void* operator new(std::size_t numBytes, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT{
 	return malloc(numBytes);
 }
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)

--- a/src/new_opv.cpp
+++ b/src/new_opv.cpp
@@ -17,13 +17,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-// Arduino 1.0 contains an implementation for this.
-#if ARDUINO < 100
-
 #include <new>
 #include <cstdlib>
 #include <func_exception>
 
+#if defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100
 _UCXXEXPORT void* operator new[](std::size_t numBytes)_UCXX_THROW(std::bad_alloc){
 	//C++ stardard 5.3.4.8 requires that a valid pointer be returned for
 	//a call to new(0). Thus:
@@ -37,4 +35,4 @@ _UCXXEXPORT void* operator new[](std::size_t numBytes)_UCXX_THROW(std::bad_alloc
 	return p;
 }
 
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && ARDUINO < 100

--- a/src/new_opvnt.cpp
+++ b/src/new_opvnt.cpp
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "new"
-#include "cstdlib"
-#include "func_exception"
+#include <new>
+#include <cstdlib>
+#include <func_exception>
 
 #ifndef NO_NOTHROW
 _UCXXEXPORT void* operator new[](std::size_t numBytes, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT{

--- a/src/new_opvnt.cpp
+++ b/src/new_opvnt.cpp
@@ -21,8 +21,8 @@
 #include <cstdlib>
 #include <func_exception>
 
-#ifndef NO_NOTHROW
+#if defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)
 _UCXXEXPORT void* operator new[](std::size_t numBytes, const std::nothrow_t& ) _UCXX_USE_NOEXCEPT{
 	return malloc(numBytes);
 }
-#endif
+#endif // defined(USING_NEW_FROM_UCLIBC) && !defined(NO_NOTHROW)

--- a/src/numeric
+++ b/src/numeric
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "exception"
+#include <basic_definitions>
+#include <exception>
 
 #ifndef __STD_NUMERIC_HEADER
 #define __STD_NUMERIC_HEADER 1

--- a/src/numeric.cpp
+++ b/src/numeric.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "numeric"
+#include <numeric>
 
 namespace std{
 

--- a/src/ostream
+++ b/src/ostream
@@ -17,15 +17,15 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef STD_HEADER_OSTREAM
 #define STD_HEADER_OSTREAM 1
 
-#include "iosfwd"
-#include "streambuf"
-#include "cstdio"
-#include "ostream_helpers"
+#include <iosfwd>
+#include <streambuf>
+#include <cstdio>
+#include <ostream_helpers>
 
 #pragma GCC visibility push(default)
 

--- a/src/ostream.cpp
+++ b/src/ostream.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_OSTREAM__ 1
 
-#include "ostream"
+#include <ostream>
 
 namespace std{
 	

--- a/src/ostream_helpers
+++ b/src/ostream_helpers
@@ -18,11 +18,11 @@
 */
 
 #include <stdint.h>
-#include "basic_definitions"
-#include "cstddef"
-#include "ios"
-#include "cctype"
-#include "string"
+#include <basic_definitions>
+#include <cstddef>
+#include <ios>
+#include <cctype>
+#include <string>
 #include <math.h> // for floor()
 
 #ifndef __STD_HEADER_OSTREAM_HELPERS

--- a/src/ostream_helpers.cpp
+++ b/src/ostream_helpers.cpp
@@ -6,7 +6,7 @@
  * 
  */
 
-#include "ostream_helpers"
+#include <ostream_helpers>
 #include <stdio.h>
 
 namespace std {

--- a/src/queue
+++ b/src/queue
@@ -15,10 +15,10 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "deque"
-#include "vector"
-#include "functional"
+#include <basic_definitions>
+#include <deque>
+#include <vector>
+#include <functional>
 
 #ifndef __HEADER_STD_QUEUE
 #define __HEADER_STD_QUEUE 1

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "queue"
+#include <queue>
 
 
 namespace std{

--- a/src/serstream
+++ b/src/serstream
@@ -43,13 +43,13 @@
 #ifndef __810370EC_AD69_4ef7_91F5_B1AA16F14712
 #define __810370EC_AD69_4ef7_91F5_B1AA16F14712
 
-#include "basic_definitions"
+#include <basic_definitions>
 
-#include "iosfwd"
-#include "ios"
-#include "istream"
-#include "ostream"
-#include "iostream"
+#include <iosfwd>
+#include <ios>
+#include <istream>
+#include <ostream>
+#include <iostream>
 #include <Stream.h>
 
 namespace std

--- a/src/set
+++ b/src/set
@@ -18,12 +18,12 @@
 
 
 
-#include "memory"
-#include "utility"
-#include "iterator"
-#include "deque"
-#include "functional"
-#include "associative_base"
+#include<memory>
+#include<utility>
+#include<iterator>
+#include <deque>
+#include<functional>
+#include <associative_base>
 
 #ifndef __STD_HEADER_SET
 #define __STD_HEADER_SET

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -17,7 +17,7 @@
 
 */
 
-#include "set"
+#include <set>
 
 namespace std{
 

--- a/src/sstream
+++ b/src/sstream
@@ -17,17 +17,17 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef HEADER_STD_SSTREAM
 #define HEADER_STD_SSTREAM 1
 
-#include "iosfwd"
-#include "ios"
-#include "istream"
-#include "ostream"
-#include "iostream"
-#include "string"
+#include <iosfwd>
+#include <ios>
+#include <istream>
+#include <ostream>
+#include <iostream>
+#include <string>
 
 #pragma GCC visibility push(default)
 

--- a/src/sstream.cpp
+++ b/src/sstream.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_SSTREAM__ 1
 
-#include "sstream"
+#include <sstream>
 
 namespace std{
 

--- a/src/stack
+++ b/src/stack
@@ -15,8 +15,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "deque"
+#include <basic_definitions>
+#include <deque>
 
 #ifndef __HEADER_STD_STACK
 #define __HEADER_STD_STACK 1

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -16,7 +16,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "stack"
+#include <stack>
 
 
 namespace std{

--- a/src/stdexcept
+++ b/src/stdexcept
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "exception"
-#include "string"
+#include <basic_definitions>
+#include <exception>
+#include <string>
 
 #ifndef HEADER_STD_EXCEPTIONS
 #define HEADER_STD_EXCEPTIONS 1

--- a/src/stdexcept.cpp
+++ b/src/stdexcept.cpp
@@ -17,8 +17,8 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "exception"
-#include "stdexcept"
+#include <exception>
+#include <stdexcept>
 
 #ifdef __UCLIBCXX_EXCEPTION_SUPPORT__
 

--- a/src/streambuf
+++ b/src/streambuf
@@ -17,15 +17,15 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "locale"
-#include "string"
-#include "iosfwd"
+#include <basic_definitions>
+#include <locale>
+#include <string>
+#include <iosfwd>
 
 #ifndef HEADER_STD_STREAMBUF
 #define HEADER_STD_STREAMBUF 1
 
-#include "ios"
+#include <ios>
 
 #pragma GCC visibility push(default)
 

--- a/src/streambuf.cpp
+++ b/src/streambuf.cpp
@@ -19,7 +19,7 @@
 
 #define __UCLIBCXX_COMPILE_STREAMBUF__ 1
 
-#include "streambuf"
+#include <streambuf>
 
 namespace std{
 

--- a/src/string
+++ b/src/string
@@ -17,17 +17,17 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
-#include "char_traits"
+#include <basic_definitions>
+#include <char_traits>
 #include <string.h>
-#include "func_exception"
-#include "memory"
-#include "vector"
+#include <func_exception>
+#include <memory>
+#include <vector>
 
 
 #ifdef __UCLIBCXX_HAS_WCHAR__
-#include "cwchar"
-#include "cwctype"
+#include <cwchar>
+#include <cwctype>
 #endif
 
 #ifndef __HEADER_STD_STRING

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -19,12 +19,12 @@
 
 #define __UCLIBCXX_COMPILE_STRING__ 1
 
-#include "basic_definitions"
-#include "char_traits"
-#include "string"
-#include "string_iostream"
+#include <basic_definitions>
+#include <char_traits>
+#include <string>
+#include <string_iostream>
 #include <string.h>
-#include "ostream"
+#include <ostream>
 
 namespace std{
 

--- a/src/string_iostream
+++ b/src/string_iostream
@@ -17,13 +17,13 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "istream"
-#include "ostream"
-#include "string"
+#include <istream>
+#include <ostream>
+#include <string>
 
 #ifdef __UCLIBCXX_HAS_WCHAR__
-#include "cwchar"
-#include "cwctype"
+#include <cwchar>
+#include <cwctype>
 #endif
 
 #ifndef __HEADER_STD_STRING_IOSTREAM

--- a/src/support
+++ b/src/support
@@ -17,9 +17,9 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "exception"
-#include "cstdlib"
-#include "typeinfo"
+#include <exception>
+#include <cstdlib>
+#include <typeinfo>
 
 #ifndef HEADER_ULC_SUPPORT
 #define HEADER_ULC_SUPPORT 1

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "support"
+#include <support>
 
 /*extern "C" void *__cxa_allocate_exception(size_t thrown_size){
 	void * retval;

--- a/src/type_traits
+++ b/src/type_traits
@@ -16,11 +16,11 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
+#include <basic_definitions>
 #include <string.h>
-#include "exception"
-#include "memory"
-#include "char_traits"
+#include <exception>
+#include <memory>
+#include <char_traits>
 
 #ifndef __HEADER_TYPE_TRAITS
 #define __HEADER_TYPE_TRAITS 1

--- a/src/typeinfo
+++ b/src/typeinfo
@@ -35,7 +35,7 @@
 #ifndef __TYPEINFO__
 #define __TYPEINFO__
 
-#include "exception"
+#include <exception>
 
 extern "C++" {
 

--- a/src/typeinfo.cpp
+++ b/src/typeinfo.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "typeinfo"
+#include <typeinfo>
 
 namespace std{
 

--- a/src/unwind-cxx.h
+++ b/src/unwind-cxx.h
@@ -1,4 +1,3 @@
-// -*- C++ -*- Exception handling and frame unwind runtime interface routines.
 // Copyright (C) 2001 Free Software Foundation, Inc.
 //
 // This file is part of GCC.
@@ -35,9 +34,9 @@
 
 // Level 2: C++ ABI
 
-#include "typeinfo"
-#include "exception"
-#include "cstddef"
+#include <typeinfo>
+#include <exception>
+#include <cstddef>
 #include "unwind.h"
 
 #ifdef __aarch64__

--- a/src/utility
+++ b/src/utility
@@ -18,7 +18,7 @@
 */
 
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 
 #ifndef __STD_HEADER_UTILITY

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -18,7 +18,7 @@
 */
 
 
-#include "utility"
+#include <utility>
 
 
 namespace std{

--- a/src/valarray
+++ b/src/valarray
@@ -17,13 +17,13 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "basic_definitions"
+#include <basic_definitions>
 
 #ifndef __HEADER_STD_VALARRAY
 #define __HEADER_STD_VALARRAY 1
 
-#include "cstddef"
-#include "cmath"
+#include <cstddef>
+#include <cmath>
 
 #pragma GCC visibility push(default)
 

--- a/src/valarray.cpp
+++ b/src/valarray.cpp
@@ -17,7 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include "valarray"
+#include <valarray>
 
 namespace std{
 

--- a/src/vector
+++ b/src/vector
@@ -18,13 +18,13 @@
 
 */
 
-#include "basic_definitions"
-#include "memory"
-#include "iterator"
-#include "func_exception"
-#include "algorithm"
-#include "type_traits"
-#include "initializer_list"
+#include <basic_definitions>
+#include <memory>
+#include <iterator>
+#include <func_exception>
+#include <algorithm>
+#include <type_traits>
+#include <initializer_list>
 
 #ifndef __STD_HEADER_VECTOR
 #define __STD_HEADER_VECTOR

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -20,7 +20,7 @@
 #define __UCLIBCXX_COMPILE_VECTOR__ 1
 
 
-#include "vector"
+#include <vector>
 
 namespace std{
 


### PR DESCRIPTION
This fixes remaining issues with new/delete conflicts between this library and the AVR core by simply omitting all new-related stuff from this library when the AVR core provides it.

For more info, see https://github.com/arduino-libraries/Arduino_AVRSTL/pull/2#issuecomment-1008798285 and the commit message of the main commit of this PR:

    Since AVR core 1.8.3, it provides an (incomplete) new header that breaks
    compilation of the uclibc++ new/delete .cpp files. Since 1.8.4 it
    provides a complete new header, but that also introduces a linker
    duplicate symbol issue for std::nothrow.
    
    This commit adds a USING_NEW_FROM_UCLIBC define to our new include file,
    which allows detecting which version of the new include is used. That
    define is used to completely skip all new/delete code (all new_*.cpp and
    del_*.cpp files) when the new header from the AVR-core is used.
    
    This should fix all conflicts, except:
     - On AVR core 1.8.3, new/delete is now incomplete. However, the missing
       functions (array placement new, placement delete, nothrow versions
       and delete with size) are probably not commonly used.
     - If another library *also* offers <new>, then things might break in
       different ways. Again, this is a rare corner case.
     - This no longer provides set_new_handler, which the AVR core declares
       but does not define. However, since the uclibc++ version did not
       actually *use* the handler passed, not defining it is probably
       better.


This PR was previously submitted against Arduino_AVRSTL, but since this repo seems to be a bit more active again and Arduino [stopped maintaining their fork](https://github.com/arduino-libraries/Arduino_AVRSTL/pull/13), I'm resubmitting this here.