### PR TITLE
Revert "feat: Add compatibility for std::move function"

### DIFF
--- a/src/utility
+++ b/src/utility
@@ -80,11 +80,7 @@ namespace std{
 		return pair<T1,T2>(x, y);
 	}
 
-	// Stubb out move for compatibility
-	template<class T>
-	T& move(T& t) noexcept {
-		return t;
-	}
+
 }
 
 #pragma GCC visibility pop


### PR DESCRIPTION
The implementation was incorrect (returning T& instead of T&&). Until
a working version is provided (which requires additional work), it would
be better to not provide it at all. Users that need this can use other
libraries to complement ArduinoSTL with C++11 bits already, like
https://github.com/hideakitai/ArxTypeTraits (and see also https://github.com/mike-matera/ArduinoSTL/pull/52#issuecomment-1170130501)

This reverts commit 75367269a46acc8304e48fcaa886a275644bf8cb.