### PR TITLE
Removed definition of `std::nothrow`.

### DIFF
--- a/src/new_handler.cpp
+++ b/src/new_handler.cpp
@@ -19,8 +19,6 @@
 
 #include "new"
 
-const std::nothrow_t std::nothrow = { };
-
 //Name selected to be compatable with g++ code
 std::new_handler __new_handler;
 


### PR DESCRIPTION
Fixes #84.