### PR TITLE
fix: Duplicate `std::nothrow` for avr-gcc

### DIFF
--- a/src/new_handler.cpp
+++ b/src/new_handler.cpp
@@ -19,7 +19,9 @@
 
 #include "new"
 
-const std::nothrow_t std::nothrow = { };
+#ifndef __AVR_ARCH__
+	const std::nothrow_t std::nothrow = { };
+#endif
 
 //Name selected to be compatable with g++ code
 std::new_handler __new_handler;


### PR DESCRIPTION
Possible fix for #95.